### PR TITLE
whoami: Add command to display account information

### DIFF
--- a/cmd/initialize/cmd.go
+++ b/cmd/initialize/cmd.go
@@ -118,7 +118,7 @@ func run(cmd *cobra.Command, argv []string) {
 		}
 
 		if isLoggedIn {
-			username, err := cfg.UserName()
+			username, err := cfg.GetData("username")
 			if err != nil {
 				reporter.Errorf("Failed to get username: %v", err)
 				os.Exit(1)

--- a/cmd/login/cmd.go
+++ b/cmd/login/cmd.go
@@ -271,7 +271,7 @@ func run(cmd *cobra.Command, argv []string) {
 		os.Exit(1)
 	}
 
-	username, err := cfg.UserName()
+	username, err := cfg.GetData("username")
 	if err != nil {
 		reporter.Errorf("Failed to get username: %v", err)
 		os.Exit(1)

--- a/cmd/whoami/cmd.go
+++ b/cmd/whoami/cmd.go
@@ -1,0 +1,150 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package whoami
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/openshift/moactl/pkg/aws"
+	"github.com/openshift/moactl/pkg/logging"
+	"github.com/openshift/moactl/pkg/ocm"
+	"github.com/openshift/moactl/pkg/ocm/config"
+	rprtr "github.com/openshift/moactl/pkg/reporter"
+)
+
+var Cmd = &cobra.Command{
+	Use:   "whoami",
+	Short: "Displays user account information",
+	Long:  "Displays information about your AWS and Red Hat accounts",
+	Example: `  # Displays user information
+  moactl whoami`,
+	Run: run,
+}
+
+func run(_ *cobra.Command, _ []string) {
+	// Create the reporter:
+	reporter, err := rprtr.New().
+		Build()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to create reporter: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Create the logger:
+	logger, err := logging.NewLogger().Build()
+	if err != nil {
+		reporter.Errorf("Failed to create logger: %v", err)
+		os.Exit(1)
+	}
+
+	// Create the AWS client:
+	awsClient, err := aws.NewClient().
+		Logger(logger).
+		Build()
+	if err != nil {
+		reporter.Errorf("failed to create AWS client: %v", err)
+		os.Exit(1)
+	}
+
+	// Get current AWS account information:
+	awsCreator, err := awsClient.GetCreator()
+	if err != nil {
+		reporter.Errorf("failed to get AWS creator: %v", err)
+		os.Exit(1)
+	}
+
+	// Get default AWS region:
+	awsRegion, err := aws.GetRegion("")
+	if err != nil {
+		reporter.Errorf("Error getting AWS region: %v", err)
+		os.Exit(1)
+	}
+
+	// Load the configuration file:
+	cfg, err := config.Load()
+	if err != nil {
+		reporter.Errorf("Failed to load config file: %v", err)
+		os.Exit(1)
+	}
+	if cfg == nil {
+		reporter.Errorf("User is not logged in to OCM")
+		os.Exit(0)
+	}
+
+	// Verify configuration file:
+	loggedIn, err := cfg.Armed()
+	if err != nil {
+		reporter.Errorf("Failed to verify configuration: %v", err)
+		os.Exit(1)
+	}
+	if !loggedIn {
+		reporter.Errorf("User is not logged in to OCM")
+		os.Exit(0)
+	}
+
+	// Create a connection to OCM:
+	connection, err := ocm.NewConnection().
+		Config(cfg).
+		Logger(logger).
+		Build()
+	if err != nil {
+		reporter.Errorf("Failed to create OCM connection: %v", err)
+		os.Exit(1)
+	}
+	defer func() {
+		err = connection.Close()
+		if err != nil {
+			reporter.Errorf("Failed to close OCM connection: %v", err)
+		}
+	}()
+
+	// Get current OCM account:
+	response, err := connection.AccountsMgmt().V1().CurrentAccount().Get().Send()
+	if err != nil {
+		reporter.Errorf("Failed to get current account: %v", err)
+		os.Exit(1)
+	}
+	account := response.Body()
+	fmt.Printf(""+
+		"AWS Account ID:           %s\n"+
+		"AWS Default Region:       %s\n"+
+		"AWS ARN:                  %s\n"+
+		"OpenShift API:            %s\n"+
+		"Account ID:               %s\n"+
+		"Account Name:             %s %s\n"+
+		"Account Username:         %s\n"+
+		"Account Email:            %s\n"+
+		"Organization ID:          %s\n"+
+		"Organization Name:        %s\n"+
+		"Organization External ID: %s\n",
+		awsCreator.AccountID,
+		awsRegion,
+		awsCreator.ARN,
+		cfg.URL,
+		account.ID(),
+		account.FirstName(), account.LastName(),
+		account.Username(),
+		account.Email(),
+		account.Organization().ID(),
+		account.Organization().Name(),
+		account.Organization().ExternalID(),
+	)
+	fmt.Println()
+}

--- a/docs/moactl.md
+++ b/docs/moactl.md
@@ -28,4 +28,5 @@ Command line tool for MOA.
 * [moactl logs](moactl_logs.md)	 - Show logs of a specific resource
 * [moactl verify](moactl_verify.md)	 - Verify resources are configured correctly for cluster install
 * [moactl version](moactl_version.md)	 - Prints the version of the tool
+* [moactl whoami](moactl_whoami.md)	 - Displays user account information
 

--- a/docs/moactl_whoami.md
+++ b/docs/moactl_whoami.md
@@ -1,0 +1,36 @@
+## moactl whoami
+
+Displays user account information
+
+### Synopsis
+
+Displays information about your AWS and Red Hat accounts
+
+```
+moactl whoami [flags]
+```
+
+### Examples
+
+```
+  # Displays user information
+  moactl whoami
+```
+
+### Options
+
+```
+  -h, --help   help for whoami
+```
+
+### Options inherited from parent commands
+
+```
+      --debug     Enable debug mode.
+  -v, --v Level   log level for V logs
+```
+
+### SEE ALSO
+
+* [moactl](moactl.md)	 - 
+

--- a/main.go
+++ b/main.go
@@ -37,6 +37,7 @@ import (
 	"github.com/openshift/moactl/cmd/logs"
 	"github.com/openshift/moactl/cmd/verify"
 	"github.com/openshift/moactl/cmd/version"
+	"github.com/openshift/moactl/cmd/whoami"
 
 	"github.com/openshift/moactl/pkg/arguments"
 )
@@ -69,6 +70,7 @@ func init() {
 	root.AddCommand(logs.Cmd)
 	root.AddCommand(verify.Cmd)
 	root.AddCommand(version.Cmd)
+	root.AddCommand(whoami.Cmd)
 }
 
 func main() {

--- a/pkg/ocm/config/config.go
+++ b/pkg/ocm/config/config.go
@@ -134,7 +134,7 @@ func Location() (path string, err error) {
 	return path, nil
 }
 
-func (c *Config) UserName() (username string, err error) {
+func (c *Config) GetData(key string) (value string, err error) {
 	if c.AccessToken == "" {
 		return
 	}
@@ -150,14 +150,14 @@ func (c *Config) UserName() (username string, err error) {
 		err = fmt.Errorf("Expected map claims but got %T", claims)
 		return
 	}
-	claim, ok := claims["username"]
+	claim, ok := claims[key]
 	if !ok {
-		err = fmt.Errorf("Token does not contain the 'username' claim")
+		err = fmt.Errorf("Token does not contain the '%s' claim", key)
 		return
 	}
-	username, ok = claim.(string)
+	value, ok = claim.(string)
 	if !ok {
-		err = fmt.Errorf("Expected string 'username' but got %T", claim)
+		err = fmt.Errorf("Expected string '%s' but got %T", key, claim)
 		return
 	}
 


### PR DESCRIPTION
This new command outputs information about the current account
configurations for both AWS and Red Hat. It also displays which
OpenShift API environment the user is logged into through OCM.