### PR TITLE
CreateReporterOrExit function for commands

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -164,13 +164,7 @@ func init() {
 }
 
 func run(cmd *cobra.Command, _ []string) {
-	// Create the reporter:
-	reporter, err := rprtr.New().
-		Build()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to create reporter: %v\n", err)
-		os.Exit(1)
-	}
+	reporter := rprtr.CreateReporterOrExit()
 
 	// Create the logger:
 	logger, err := logging.NewLogger().Build()

--- a/cmd/create/idp/cmd.go
+++ b/cmd/create/idp/cmd.go
@@ -221,13 +221,7 @@ func init() {
 }
 
 func run(_ *cobra.Command, _ []string) {
-	// Create the reporter:
-	reporter, err := rprtr.New().
-		Build()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to create reporter: %v\n", err)
-		os.Exit(1)
-	}
+	reporter := rprtr.CreateReporterOrExit()
 
 	// Create the logger:
 	logger, err := logging.NewLogger().Build()

--- a/cmd/create/ingress/cmd.go
+++ b/cmd/create/ingress/cmd.go
@@ -17,7 +17,6 @@ limitations under the License.
 package ingress
 
 import (
-	"fmt"
 	"os"
 	"strings"
 
@@ -81,13 +80,7 @@ func init() {
 }
 
 func run(cmd *cobra.Command, _ []string) {
-	// Create the reporter:
-	reporter, err := rprtr.New().
-		Build()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to create reporter: %v\n", err)
-		os.Exit(1)
-	}
+	reporter := rprtr.CreateReporterOrExit()
 
 	// Create the logger:
 	logger, err := logging.NewLogger().Build()

--- a/cmd/create/user/cmd.go
+++ b/cmd/create/user/cmd.go
@@ -17,7 +17,6 @@ limitations under the License.
 package user
 
 import (
-	"fmt"
 	"os"
 	"strings"
 
@@ -81,13 +80,7 @@ func init() {
 }
 
 func run(_ *cobra.Command, _ []string) {
-	// Create the reporter:
-	reporter, err := rprtr.New().
-		Build()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to create reporter: %v\n", err)
-		os.Exit(1)
-	}
+	reporter := rprtr.CreateReporterOrExit()
 
 	// Create the logger:
 	logger, err := logging.NewLogger().Build()

--- a/cmd/describe/cluster/cmd.go
+++ b/cmd/describe/cluster/cmd.go
@@ -58,13 +58,7 @@ func init() {
 }
 
 func run(_ *cobra.Command, argv []string) {
-	// Create the reporter:
-	reporter, err := rprtr.New().
-		Build()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to create reporter: %v\n", err)
-		os.Exit(1)
-	}
+	reporter := rprtr.CreateReporterOrExit()
 
 	// Create the logger:
 	logger, err := logging.NewLogger().Build()

--- a/cmd/dlt/cluster/cmd.go
+++ b/cmd/dlt/cluster/cmd.go
@@ -17,7 +17,6 @@ limitations under the License.
 package cluster
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -58,13 +57,7 @@ func init() {
 }
 
 func run(_ *cobra.Command, argv []string) {
-	// Create the reporter:
-	reporter, err := rprtr.New().
-		Build()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to create reporter: %v\n", err)
-		os.Exit(1)
-	}
+	reporter := rprtr.CreateReporterOrExit()
 
 	// Create the logger:
 	logger, err := logging.NewLogger().Build()

--- a/cmd/dlt/idp/cmd.go
+++ b/cmd/dlt/idp/cmd.go
@@ -17,7 +17,6 @@ limitations under the License.
 package idp
 
 import (
-	"fmt"
 	"os"
 
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
@@ -57,13 +56,7 @@ func init() {
 }
 
 func run(_ *cobra.Command, argv []string) {
-	// Create the reporter:
-	reporter, err := rprtr.New().
-		Build()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to create reporter: %v\n", err)
-		os.Exit(1)
-	}
+	reporter := rprtr.CreateReporterOrExit()
 
 	// Create the logger:
 	logger, err := logging.NewLogger().Build()

--- a/cmd/dlt/ingress/cmd.go
+++ b/cmd/dlt/ingress/cmd.go
@@ -17,7 +17,6 @@ limitations under the License.
 package ingress
 
 import (
-	"fmt"
 	"os"
 	"regexp"
 
@@ -65,13 +64,7 @@ func init() {
 }
 
 func run(_ *cobra.Command, argv []string) {
-	// Create the reporter:
-	reporter, err := rprtr.New().
-		Build()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to create reporter: %v\n", err)
-		os.Exit(1)
-	}
+	reporter := rprtr.CreateReporterOrExit()
 
 	// Create the logger:
 	logger, err := logging.NewLogger().Build()

--- a/cmd/dlt/user/cmd.go
+++ b/cmd/dlt/user/cmd.go
@@ -17,7 +17,6 @@ limitations under the License.
 package user
 
 import (
-	"fmt"
 	"os"
 	"strings"
 
@@ -80,13 +79,7 @@ func init() {
 }
 
 func run(_ *cobra.Command, _ []string) {
-	// Create the reporter:
-	reporter, err := rprtr.New().
-		Build()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to create reporter: %v\n", err)
-		os.Exit(1)
-	}
+	reporter := rprtr.CreateReporterOrExit()
 
 	// Create the logger:
 	logger, err := logging.NewLogger().Build()

--- a/cmd/edit/cluster/cmd.go
+++ b/cmd/edit/cluster/cmd.go
@@ -114,13 +114,7 @@ func init() {
 }
 
 func run(cmd *cobra.Command, argv []string) {
-	// Create the reporter:
-	reporter, err := rprtr.New().
-		Build()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to create reporter: %v\n", err)
-		os.Exit(1)
-	}
+	reporter := rprtr.CreateReporterOrExit()
 
 	// Check command line arguments:
 	clusterKey := args.clusterKey

--- a/cmd/edit/ingress/cmd.go
+++ b/cmd/edit/ingress/cmd.go
@@ -17,7 +17,6 @@ limitations under the License.
 package ingress
 
 import (
-	"fmt"
 	"os"
 	"regexp"
 	"strings"
@@ -87,13 +86,7 @@ func init() {
 }
 
 func run(cmd *cobra.Command, argv []string) {
-	// Create the reporter:
-	reporter, err := rprtr.New().
-		Build()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to create reporter: %v\n", err)
-		os.Exit(1)
-	}
+	reporter := rprtr.CreateReporterOrExit()
 
 	// Create the logger:
 	logger, err := logging.NewLogger().Build()

--- a/cmd/initialize/cmd.go
+++ b/cmd/initialize/cmd.go
@@ -73,13 +73,7 @@ func init() {
 }
 
 func run(cmd *cobra.Command, argv []string) {
-	// Create the reporter:
-	reporter, err := rprtr.New().
-		Build()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to create reporter: %v\n", err)
-		os.Exit(1)
-	}
+	reporter := rprtr.CreateReporterOrExit()
 
 	// Create the logger:
 	logger, err := logging.NewLogger().Build()

--- a/cmd/list/cluster/cmd.go
+++ b/cmd/list/cluster/cmd.go
@@ -58,13 +58,7 @@ func init() {
 }
 
 func run(_ *cobra.Command, argv []string) {
-	// Create the reporter:
-	reporter, err := rprtr.New().
-		Build()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to create reporter: %v\n", err)
-		os.Exit(1)
-	}
+	reporter := rprtr.CreateReporterOrExit()
 
 	// Create the logger:
 	logger, err := logging.NewLogger().Build()

--- a/cmd/list/idp/cmd.go
+++ b/cmd/list/idp/cmd.go
@@ -59,13 +59,7 @@ func init() {
 }
 
 func run(_ *cobra.Command, _ []string) {
-	// Create the reporter:
-	reporter, err := rprtr.New().
-		Build()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to create reporter: %v\n", err)
-		os.Exit(1)
-	}
+	reporter := rprtr.CreateReporterOrExit()
 
 	// Create the logger:
 	logger, err := logging.NewLogger().Build()

--- a/cmd/list/ingress/cmd.go
+++ b/cmd/list/ingress/cmd.go
@@ -59,13 +59,7 @@ func init() {
 }
 
 func run(_ *cobra.Command, _ []string) {
-	// Create the reporter:
-	reporter, err := rprtr.New().
-		Build()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to create reporter: %v\n", err)
-		os.Exit(1)
-	}
+	reporter := rprtr.CreateReporterOrExit()
 
 	// Create the logger:
 	logger, err := logging.NewLogger().Build()

--- a/cmd/list/user/cmd.go
+++ b/cmd/list/user/cmd.go
@@ -58,13 +58,7 @@ func init() {
 }
 
 func run(_ *cobra.Command, _ []string) {
-	// Create the reporter:
-	reporter, err := rprtr.New().
-		Build()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to create reporter: %v\n", err)
-		os.Exit(1)
-	}
+	reporter := rprtr.CreateReporterOrExit()
 
 	// Create the logger:
 	logger, err := logging.NewLogger().Build()

--- a/cmd/login/cmd.go
+++ b/cmd/login/cmd.go
@@ -119,13 +119,7 @@ func init() {
 }
 
 func run(cmd *cobra.Command, argv []string) {
-	// Create the reporter:
-	reporter, err := rprtr.New().
-		Build()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to create reporter: %v\n", err)
-		os.Exit(1)
-	}
+	reporter := rprtr.CreateReporterOrExit()
 
 	// Create the logger:
 	logger, err := logging.NewLogger().Build()

--- a/cmd/logs/cluster/cmd.go
+++ b/cmd/logs/cluster/cmd.go
@@ -65,13 +65,7 @@ func init() {
 }
 
 func run(_ *cobra.Command, argv []string) {
-	// Create the reporter:
-	reporter, err := rprtr.New().
-		Build()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to create reporter: %v\n", err)
-		os.Exit(1)
-	}
+	reporter := rprtr.CreateReporterOrExit()
 
 	// Create the logger:
 	logger, err := logging.NewLogger().Build()

--- a/cmd/verify/permissions/cmd.go
+++ b/cmd/verify/permissions/cmd.go
@@ -17,7 +17,6 @@ limitations under the License.
 package permissions
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -39,13 +38,7 @@ var Cmd = &cobra.Command{
 }
 
 func run(cmd *cobra.Command, argv []string) {
-	// Create the reporter:
-	reporter, err := rprtr.New().
-		Build()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to create reporter: %v\n", err)
-		os.Exit(1)
-	}
+	reporter := rprtr.CreateReporterOrExit()
 
 	// Create the logger:
 	logger, err := logging.NewLogger().Build()

--- a/cmd/verify/quota/cmd.go
+++ b/cmd/verify/quota/cmd.go
@@ -17,7 +17,6 @@ limitations under the License.
 package quota
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -39,13 +38,7 @@ var Cmd = &cobra.Command{
 }
 
 func run(cmd *cobra.Command, argv []string) {
-	// Create the reporter:
-	reporter, err := rprtr.New().
-		Build()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to create reporter: %v\n", err)
-		os.Exit(1)
-	}
+	reporter := rprtr.CreateReporterOrExit()
 
 	// Create the logger:
 	logger, err := logging.NewLogger().Build()

--- a/pkg/reporter/reporter.go
+++ b/pkg/reporter/reporter.go
@@ -89,3 +89,16 @@ const (
 	warnPrefix  = "\033[0;33mW:\033[m "
 	errorPrefix = "\033[0;31mE:\033[m "
 )
+
+// CreateReporterOrExit creates the reportor instance or exits to the console
+// noting the error on failure.
+func CreateReporterOrExit() *Object {
+	// Create the reporter:
+	reporter, err := New().
+		Build()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to create reporter: %v\n", err)
+		os.Exit(1)
+	}
+	return reporter
+}


### PR DESCRIPTION
- Add `CreateReporterOrExit` function to reporter
- Use it in commands rather than the same code block

Admittedly not well tested but seems like it's a safe change :smile: 