### PR TITLE
logs: Allow the use of --cluster as identifier

### DIFF
--- a/cmd/logs/cmd.go
+++ b/cmd/logs/cmd.go
@@ -23,9 +23,10 @@ import (
 )
 
 var Cmd = &cobra.Command{
-	Use:   "logs RESOURCE [flags]",
-	Short: "Show logs of a specific resource",
-	Long:  "Show logs of a specific resource",
+	Use:     "logs RESOURCE [flags]",
+	Aliases: []string{"log"},
+	Short:   "Show logs of a specific resource",
+	Long:    "Show logs of a specific resource",
 }
 
 func init() {

--- a/docs/moactl_logs_cluster.md
+++ b/docs/moactl_logs_cluster.md
@@ -15,14 +15,18 @@ moactl logs cluster [ID|NAME] [flags]
 ```
   # Show last 100 log lines for a cluster named "mycluster"
   moactl logs cluster mycluster --tail=100
+
+  # Show logs for a cluster using the --cluster flag
+  moactl logs cluster --cluster=mycluster
 ```
 
 ### Options
 
 ```
-  -h, --help       help for cluster
-      --tail int   Number of lines to get from the end of the log. (default 2000)
-  -w, --watch      After getting the logs, watch for changes.
+  -c, --cluster string   Name or ID of the cluster to get logs for.
+  -h, --help             help for cluster
+      --tail int         Number of lines to get from the end of the log. (default 2000)
+  -w, --watch            After getting the logs, watch for changes.
 ```
 
 ### Options inherited from parent commands


### PR DESCRIPTION
When fetching cluster logs, in addition to passing the cluster name/ID
as a command-line argument, we also allow it to be sent as a flag. This
allows for more consistent behavior across commands and resources, while
still allowing the current behavior.