### PR TITLE
errors: Expand error messages

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -252,10 +252,7 @@ func run(cmd *cobra.Command, _ []string) {
 
 	cluster, err := clusterprovider.CreateCluster(ocmClient.Clusters(), clusterConfig)
 	if err != nil {
-		// Unwrap and clean up API errors:
-		wrapped := strings.Split(err.Error(), ": ")
-		errorMessage := wrapped[len(wrapped)-1]
-		reporter.Errorf("Failed to create cluster: %v", errorMessage)
+		reporter.Errorf("Failed to create cluster: %v", err)
 		os.Exit(1)
 	}
 

--- a/cmd/create/ingress/cmd.go
+++ b/cmd/create/ingress/cmd.go
@@ -182,10 +182,7 @@ func run(cmd *cobra.Command, _ []string) {
 		Body(ingress).
 		Send()
 	if err != nil {
-		// Unwrap and clean up API errors:
-		wrapped := strings.Split(err.Error(), ": ")
-		errorMessage := wrapped[len(wrapped)-1]
-		reporter.Errorf("Failed to add ingress to cluster '%s': %v", clusterKey, errorMessage)
+		reporter.Errorf("Failed to add ingress to cluster '%s': %v", clusterKey, err)
 		os.Exit(1)
 	}
 }

--- a/cmd/edit/cluster/cmd.go
+++ b/cmd/edit/cluster/cmd.go
@@ -20,7 +20,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -205,10 +204,7 @@ func run(cmd *cobra.Command, argv []string) {
 	reporter.Debugf("Updating cluster '%s'", clusterKey)
 	err = clusterprovider.UpdateCluster(ocmClient.Clusters(), clusterKey, awsCreator.ARN, clusterConfig)
 	if err != nil {
-		// Unwrap and clean up API errors:
-		wrapped := strings.Split(err.Error(), ": ")
-		errorMessage := wrapped[len(wrapped)-1]
-		reporter.Errorf("Failed to update cluster: %v", errorMessage)
+		reporter.Errorf("Failed to update cluster: %v", err)
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
In the past we parsed error messages coming from OCM and display only
a portion of this. This is not scalable, as we cannot know what the
error message structure is. This patch expands them to display the
entire error as it comes from the OCM API.