### PR TITLE
CreateLoggerOrExit function for commands

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -165,16 +165,11 @@ func init() {
 
 func run(cmd *cobra.Command, _ []string) {
 	reporter := rprtr.CreateReporterOrExit()
-
-	// Create the logger:
-	logger, err := logging.NewLogger().Build()
-	if err != nil {
-		reporter.Errorf("Failed to create logger: %v", err)
-		os.Exit(1)
-	}
+	logger := logging.CreateLoggerOrExit(reporter)
 
 	// Get cluster name
 	name := args.name
+	var err error
 	if name == "" {
 		name, err = interactive.GetInput("Cluster name")
 		if err != nil {

--- a/cmd/create/idp/cmd.go
+++ b/cmd/create/idp/cmd.go
@@ -222,13 +222,7 @@ func init() {
 
 func run(_ *cobra.Command, _ []string) {
 	reporter := rprtr.CreateReporterOrExit()
-
-	// Create the logger:
-	logger, err := logging.NewLogger().Build()
-	if err != nil {
-		reporter.Errorf("Failed to create logger: %v", err)
-		os.Exit(1)
-	}
+	logger := logging.CreateLoggerOrExit(reporter)
 
 	// Check that the cluster key (name, identifier or external identifier) given by the user
 	// is reasonably safe so that there is no risk of SQL injection:

--- a/cmd/create/ingress/cmd.go
+++ b/cmd/create/ingress/cmd.go
@@ -81,13 +81,7 @@ func init() {
 
 func run(cmd *cobra.Command, _ []string) {
 	reporter := rprtr.CreateReporterOrExit()
-
-	// Create the logger:
-	logger, err := logging.NewLogger().Build()
-	if err != nil {
-		reporter.Errorf("Failed to create logger: %v", err)
-		os.Exit(1)
-	}
+	logger := logging.CreateLoggerOrExit(reporter)
 
 	// Check that the cluster key (name, identifier or external identifier) given by the user
 	// is reasonably safe so that there is no risk of SQL injection:

--- a/cmd/create/user/cmd.go
+++ b/cmd/create/user/cmd.go
@@ -81,13 +81,7 @@ func init() {
 
 func run(_ *cobra.Command, _ []string) {
 	reporter := rprtr.CreateReporterOrExit()
-
-	// Create the logger:
-	logger, err := logging.NewLogger().Build()
-	if err != nil {
-		reporter.Errorf("Failed to create logger: %v", err)
-		os.Exit(1)
-	}
+	logger := logging.CreateLoggerOrExit(reporter)
 
 	// Check that the cluster key (name, identifier or external identifier) given by the user
 	// is reasonably safe so that there is no risk of SQL injection:

--- a/cmd/describe/cluster/cmd.go
+++ b/cmd/describe/cluster/cmd.go
@@ -59,13 +59,7 @@ func init() {
 
 func run(_ *cobra.Command, argv []string) {
 	reporter := rprtr.CreateReporterOrExit()
-
-	// Create the logger:
-	logger, err := logging.NewLogger().Build()
-	if err != nil {
-		reporter.Errorf("Failed to create logger: %v", err)
-		os.Exit(1)
-	}
+	logger := logging.CreateLoggerOrExit(reporter)
 
 	// Check command line arguments:
 	clusterKey := args.clusterKey

--- a/cmd/dlt/cluster/cmd.go
+++ b/cmd/dlt/cluster/cmd.go
@@ -58,13 +58,7 @@ func init() {
 
 func run(_ *cobra.Command, argv []string) {
 	reporter := rprtr.CreateReporterOrExit()
-
-	// Create the logger:
-	logger, err := logging.NewLogger().Build()
-	if err != nil {
-		reporter.Errorf("Failed to create logger: %v", err)
-		os.Exit(1)
-	}
+	logger := logging.CreateLoggerOrExit(reporter)
 
 	// Check command line arguments:
 	clusterKey := args.clusterKey

--- a/cmd/dlt/idp/cmd.go
+++ b/cmd/dlt/idp/cmd.go
@@ -57,13 +57,7 @@ func init() {
 
 func run(_ *cobra.Command, argv []string) {
 	reporter := rprtr.CreateReporterOrExit()
-
-	// Create the logger:
-	logger, err := logging.NewLogger().Build()
-	if err != nil {
-		reporter.Errorf("Failed to create logger: %v", err)
-		os.Exit(1)
-	}
+	logger := logging.CreateLoggerOrExit(reporter)
 
 	// Check command line arguments:
 	if len(argv) != 1 {

--- a/cmd/dlt/ingress/cmd.go
+++ b/cmd/dlt/ingress/cmd.go
@@ -65,13 +65,7 @@ func init() {
 
 func run(_ *cobra.Command, argv []string) {
 	reporter := rprtr.CreateReporterOrExit()
-
-	// Create the logger:
-	logger, err := logging.NewLogger().Build()
-	if err != nil {
-		reporter.Errorf("Failed to create logger: %v", err)
-		os.Exit(1)
-	}
+	logger := logging.CreateLoggerOrExit(reporter)
 
 	// Check command line arguments:
 	if len(argv) != 1 {

--- a/cmd/dlt/user/cmd.go
+++ b/cmd/dlt/user/cmd.go
@@ -80,13 +80,7 @@ func init() {
 
 func run(_ *cobra.Command, _ []string) {
 	reporter := rprtr.CreateReporterOrExit()
-
-	// Create the logger:
-	logger, err := logging.NewLogger().Build()
-	if err != nil {
-		reporter.Errorf("Failed to create logger: %v", err)
-		os.Exit(1)
-	}
+	logger := logging.CreateLoggerOrExit(reporter)
 
 	// Check that the cluster key (name, identifier or external identifier) given by the user
 	// is reasonably safe so that there is no risk of SQL injection:

--- a/cmd/edit/cluster/cmd.go
+++ b/cmd/edit/cluster/cmd.go
@@ -139,12 +139,7 @@ func run(cmd *cobra.Command, argv []string) {
 		os.Exit(1)
 	}
 
-	// Create the logger:
-	logger, err := logging.NewLogger().Build()
-	if err != nil {
-		reporter.Errorf("Failed to create logger: %v", err)
-		os.Exit(1)
-	}
+	logger := logging.CreateLoggerOrExit(reporter)
 
 	// Create the client for the OCM API:
 	ocmConnection, err := ocm.NewConnection().

--- a/cmd/edit/ingress/cmd.go
+++ b/cmd/edit/ingress/cmd.go
@@ -87,13 +87,7 @@ func init() {
 
 func run(cmd *cobra.Command, argv []string) {
 	reporter := rprtr.CreateReporterOrExit()
-
-	// Create the logger:
-	logger, err := logging.NewLogger().Build()
-	if err != nil {
-		reporter.Errorf("Failed to create logger: %v", err)
-		os.Exit(1)
-	}
+	logger := logging.CreateLoggerOrExit(reporter)
 
 	// Check command line arguments:
 	if len(argv) != 1 {

--- a/cmd/initialize/cmd.go
+++ b/cmd/initialize/cmd.go
@@ -74,13 +74,7 @@ func init() {
 
 func run(cmd *cobra.Command, argv []string) {
 	reporter := rprtr.CreateReporterOrExit()
-
-	// Create the logger:
-	logger, err := logging.NewLogger().Build()
-	if err != nil {
-		reporter.Errorf("Failed to create logger: %v", err)
-		os.Exit(1)
-	}
+	logger := logging.CreateLoggerOrExit(reporter)
 
 	// Create the AWS client:
 	client, err := aws.NewClient().

--- a/cmd/list/cluster/cmd.go
+++ b/cmd/list/cluster/cmd.go
@@ -59,13 +59,7 @@ func init() {
 
 func run(_ *cobra.Command, argv []string) {
 	reporter := rprtr.CreateReporterOrExit()
-
-	// Create the logger:
-	logger, err := logging.NewLogger().Build()
-	if err != nil {
-		reporter.Errorf("Failed to create logger: %v", err)
-		os.Exit(1)
-	}
+	logger := logging.CreateLoggerOrExit(reporter)
 
 	// Check command line arguments:
 	if len(argv) != 0 {

--- a/cmd/list/idp/cmd.go
+++ b/cmd/list/idp/cmd.go
@@ -60,13 +60,7 @@ func init() {
 
 func run(_ *cobra.Command, _ []string) {
 	reporter := rprtr.CreateReporterOrExit()
-
-	// Create the logger:
-	logger, err := logging.NewLogger().Build()
-	if err != nil {
-		reporter.Errorf("Failed to create logger: %v", err)
-		os.Exit(1)
-	}
+	logger := logging.CreateLoggerOrExit(reporter)
 
 	// Check that the cluster key (name, identifier or external identifier) given by the user
 	// is reasonably safe so that there is no risk of SQL injection:

--- a/cmd/list/ingress/cmd.go
+++ b/cmd/list/ingress/cmd.go
@@ -60,13 +60,7 @@ func init() {
 
 func run(_ *cobra.Command, _ []string) {
 	reporter := rprtr.CreateReporterOrExit()
-
-	// Create the logger:
-	logger, err := logging.NewLogger().Build()
-	if err != nil {
-		reporter.Errorf("Failed to create logger: %v", err)
-		os.Exit(1)
-	}
+	logger := logging.CreateLoggerOrExit(reporter)
 
 	// Check that the cluster key (name, identifier or external identifier) given by the user
 	// is reasonably safe so that there is no risk of SQL injection:

--- a/cmd/list/user/cmd.go
+++ b/cmd/list/user/cmd.go
@@ -59,13 +59,7 @@ func init() {
 
 func run(_ *cobra.Command, _ []string) {
 	reporter := rprtr.CreateReporterOrExit()
-
-	// Create the logger:
-	logger, err := logging.NewLogger().Build()
-	if err != nil {
-		reporter.Errorf("Failed to create logger: %v", err)
-		os.Exit(1)
-	}
+	logger := logging.CreateLoggerOrExit(reporter)
 
 	// Check that the cluster key (name, identifier or external identifier) given by the user
 	// is reasonably safe so that there is no risk of SQL injection:

--- a/cmd/login/cmd.go
+++ b/cmd/login/cmd.go
@@ -120,13 +120,7 @@ func init() {
 
 func run(cmd *cobra.Command, argv []string) {
 	reporter := rprtr.CreateReporterOrExit()
-
-	// Create the logger:
-	logger, err := logging.NewLogger().Build()
-	if err != nil {
-		reporter.Errorf("Failed to create logger: %v", err)
-		os.Exit(1)
-	}
+	logger := logging.CreateLoggerOrExit(reporter)
 
 	// Check mandatory options:
 	if args.env == "" {

--- a/cmd/logs/cluster/cmd.go
+++ b/cmd/logs/cluster/cmd.go
@@ -79,13 +79,7 @@ func init() {
 
 func run(_ *cobra.Command, argv []string) {
 	reporter := rprtr.CreateReporterOrExit()
-
-	// Create the logger:
-	logger, err := logging.NewLogger().Build()
-	if err != nil {
-		reporter.Errorf("Failed to create logger: %v", err)
-		os.Exit(1)
-	}
+	logger := logging.CreateLoggerOrExit(reporter)
 
 	// Check command line arguments:
 	clusterKey := args.clusterKey

--- a/cmd/verify/permissions/cmd.go
+++ b/cmd/verify/permissions/cmd.go
@@ -39,13 +39,7 @@ var Cmd = &cobra.Command{
 
 func run(cmd *cobra.Command, argv []string) {
 	reporter := rprtr.CreateReporterOrExit()
-
-	// Create the logger:
-	logger, err := logging.NewLogger().Build()
-	if err != nil {
-		reporter.Errorf("Failed to create logger: %v", err)
-		os.Exit(1)
-	}
+	logger := logging.CreateLoggerOrExit(reporter)
 
 	// Create the AWS client:
 	client, err := aws.NewClient().

--- a/cmd/verify/quota/cmd.go
+++ b/cmd/verify/quota/cmd.go
@@ -39,13 +39,7 @@ var Cmd = &cobra.Command{
 
 func run(cmd *cobra.Command, argv []string) {
 	reporter := rprtr.CreateReporterOrExit()
-
-	// Create the logger:
-	logger, err := logging.NewLogger().Build()
-	if err != nil {
-		reporter.Errorf("Failed to create logger: %v", err)
-		os.Exit(1)
-	}
+	logger := logging.CreateLoggerOrExit(reporter)
 
 	// Create the AWS client:
 	client, err := aws.NewClient().

--- a/cmd/whoami/cmd.go
+++ b/cmd/whoami/cmd.go
@@ -41,20 +41,8 @@ var Cmd = &cobra.Command{
 }
 
 func run(_ *cobra.Command, _ []string) {
-	// Create the reporter:
-	reporter, err := rprtr.New().
-		Build()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to create reporter: %v\n", err)
-		os.Exit(1)
-	}
-
-	// Create the logger:
-	logger, err := logging.NewLogger().Build()
-	if err != nil {
-		reporter.Errorf("Failed to create logger: %v", err)
-		os.Exit(1)
-	}
+	reporter := rprtr.CreateReporterOrExit()
+	logger := logging.CreateLoggerOrExit(reporter)
 
 	// Create the AWS client:
 	awsClient, err := aws.NewClient().

--- a/pkg/logging/logger.go
+++ b/pkg/logging/logger.go
@@ -19,9 +19,12 @@ limitations under the License.
 package logging
 
 import (
+	"os"
+
 	"github.com/sirupsen/logrus"
 
 	"github.com/openshift/moactl/pkg/debug"
+	rprtr "github.com/openshift/moactl/pkg/reporter"
 )
 
 // LoggerBuilder contains the information and logic needed to create the default loggers used by
@@ -50,4 +53,16 @@ func (b *LoggerBuilder) Build() (result *logrus.Logger, err error) {
 	}
 
 	return
+}
+
+// CreateLoggerOrExit creates the logger instance or exits to the console
+// noting the error on failure.
+func CreateLoggerOrExit(reporter *rprtr.Object) *logrus.Logger {
+	// Create the logger:
+	logger, err := NewLogger().Build()
+	if err != nil {
+		reporter.Errorf("Failed to create logger: %v", err)
+		os.Exit(1)
+	}
+	return logger
 }


### PR DESCRIPTION
Very similar to https://github.com/openshift/moactl/pull/15/

- Add CreateLoggerOrExit function to reporter
- Use it in commands rather than the same code block
- Update `whoami` to use the functions as well