### PR TITLE
AWS Region: Allow passing --region to verify and init commands

### DIFF
--- a/cmd/verify/cmd.go
+++ b/cmd/verify/cmd.go
@@ -29,7 +29,21 @@ var Cmd = &cobra.Command{
 	Long:  "Verify resources are configured correctly for cluster install",
 }
 
+var args struct {
+	region string
+}
+
 func init() {
+	flags := Cmd.PersistentFlags()
+
+	flags.StringVarP(
+		&args.region,
+		"region",
+		"r",
+		"",
+		"AWS region in which to run (overrides the AWS_REGION environment variable)",
+	)
+
 	Cmd.AddCommand(quota.Cmd)
 	Cmd.AddCommand(permissions.Cmd)
 }

--- a/docs/moactl_init.md
+++ b/docs/moactl_init.md
@@ -24,6 +24,7 @@ moactl init [flags]
 ### Options
 
 ```
+  -r, --region string          AWS region in which verify quota and permissions (overrides the AWS_REGION environment variable)
       --delete-stack           Deletes stack template applied to your AWS account during the 'init' command.
                                
       --client-id string       OpenID client identifier. The default value is 'cloud-services'.

--- a/docs/moactl_verify.md
+++ b/docs/moactl_verify.md
@@ -9,7 +9,8 @@ Verify resources are configured correctly for cluster install
 ### Options
 
 ```
-  -h, --help   help for verify
+  -h, --help            help for verify
+  -r, --region string   AWS region in which to run (overrides the AWS_REGION environment variable)
 ```
 
 ### Options inherited from parent commands

--- a/docs/moactl_verify_permissions.md
+++ b/docs/moactl_verify_permissions.md
@@ -4,7 +4,7 @@ Verify AWS permissions are ok for cluster install
 
 ### Synopsis
 
-Verify AWS permissions are ok for cluster install
+Verify AWS permissions needed to create a cluster are configured as expected
 
 ```
 moactl verify permissions [flags]
@@ -13,10 +13,11 @@ moactl verify permissions [flags]
 ### Examples
 
 ```
-  # Verify resources needed to create a cluster are configured as expected
-
   # Verify AWS permissions are configured correctly
   moactl verify permissions
+
+  # Verify AWS permissions in a different region
+  moactl verify permissions --region=us-west-2
 ```
 
 ### Options
@@ -28,8 +29,9 @@ moactl verify permissions [flags]
 ### Options inherited from parent commands
 
 ```
-      --debug     Enable debug mode.
-  -v, --v Level   log level for V logs
+      --debug           Enable debug mode.
+  -r, --region string   AWS region in which to run (overrides the AWS_REGION environment variable)
+  -v, --v Level         log level for V logs
 ```
 
 ### SEE ALSO

--- a/docs/moactl_verify_quota.md
+++ b/docs/moactl_verify_quota.md
@@ -4,7 +4,7 @@ Verify AWS quota is ok for cluster install
 
 ### Synopsis
 
-Verify AWS quota is ok for cluster install
+Verify AWS quota needed to create a cluster is configured as expected
 
 ```
 moactl verify quota [flags]
@@ -13,10 +13,11 @@ moactl verify quota [flags]
 ### Examples
 
 ```
-  # Verify resources needed to create a cluster are configured as expected
-
   # Verify AWS quotas are configured correctly
   moactl verify quota
+
+  # Verify AWS quotas in a different region
+  moactl verify quota --region=us-west-2
 ```
 
 ### Options
@@ -28,8 +29,9 @@ moactl verify quota [flags]
 ### Options inherited from parent commands
 
 ```
-      --debug     Enable debug mode.
-  -v, --v Level   log level for V logs
+      --debug           Enable debug mode.
+  -r, --region string   AWS region in which to run (overrides the AWS_REGION environment variable)
+  -v, --v Level         log level for V logs
 ```
 
 ### SEE ALSO


### PR DESCRIPTION
When verifying quota or permissions, these commands defaults to the
locally-configured AWS region. However, since clusters can be installed
with the --region flag, the verify commands may not representative of
the region in which a cluster will be installed.