### PR TITLE
interactive: Add interactive flag to create idp

### DIFF
--- a/docs/moactl_create_idp.md
+++ b/docs/moactl_create_idp.md
@@ -17,7 +17,7 @@ moactl create idp [flags]
   moactl create idp --type=github --cluster=mycluster
 
   # Add an identity provider following interactive prompts
-  moactl create idp --cluster=mycluster
+  moactl create idp --cluster=mycluster --interactive
 ```
 
 ### Options

--- a/pkg/interactive/interactive.go
+++ b/pkg/interactive/interactive.go
@@ -19,9 +19,12 @@ package interactive
 import (
 	"fmt"
 	"net"
+	"os"
 	"strconv"
 
 	"github.com/AlecAivazis/survey/v2"
+	"github.com/AlecAivazis/survey/v2/core"
+	"github.com/AlecAivazis/survey/v2/terminal"
 )
 
 type Input struct {
@@ -177,6 +180,28 @@ func GetPassword(input Input) (a string, err error) {
 		Message: fmt.Sprintf("%s:", input.Question),
 		Help:    input.Help,
 	}
+	if input.Required {
+		err = survey.AskOne(prompt, &a, survey.WithValidator(survey.Required))
+		return
+	}
 	err = survey.AskOne(prompt, &a)
 	return
+}
+
+var helpTemplate = `{{color "cyan"}}? {{.Message}}
+{{range .Steps}}  - {{.}}{{"\n"}}{{end}}{{color "reset"}}`
+
+type Help struct {
+	Message string
+	Steps   []string
+}
+
+func PrintHelp(help Help) error {
+	out, err := core.RunTemplate(helpTemplate, help)
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprint(terminal.NewAnsiStdout(os.Stdout), out)
+	return nil
 }


### PR DESCRIPTION
This adds support for the interactive flag on the `create idp` command.
Currently supported by GitHub and Google IdPs. The OpenID and LDAP
options will fall back to the legacy interactive mode.

Demo: https://asciinema.org/a/Koqdz81jtapuawl3rxRe7qOK8