### PR TITLE
interactive: Add interactive mode to edit cluster

### DIFF
--- a/cmd/edit/cmd.go
+++ b/cmd/edit/cmd.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/openshift/moactl/cmd/edit/cluster"
 	"github.com/openshift/moactl/cmd/edit/ingress"
+	"github.com/openshift/moactl/pkg/interactive"
 )
 
 var Cmd = &cobra.Command{
@@ -33,4 +34,7 @@ var Cmd = &cobra.Command{
 func init() {
 	Cmd.AddCommand(cluster.Cmd)
 	Cmd.AddCommand(ingress.Cmd)
+
+	flags := Cmd.PersistentFlags()
+	interactive.AddFlag(flags)
 }

--- a/docs/moactl_edit.md
+++ b/docs/moactl_edit.md
@@ -9,7 +9,8 @@ Edit a specific resource
 ### Options
 
 ```
-  -h, --help   help for edit
+  -h, --help          help for edit
+  -i, --interactive   Enable interactive mode.
 ```
 
 ### Options inherited from parent commands

--- a/docs/moactl_edit_cluster.md
+++ b/docs/moactl_edit_cluster.md
@@ -18,25 +18,27 @@ moactl edit cluster [flags]
 
   # Enable the cluster-admins group using the --cluster flag
   moactl edit cluster --cluster=mycluster --enable-cluster-admins
+
+  # Edit all options interactively
+  moactl edit cluster -c mycluster --interactive
 ```
 
 ### Options
 
 ```
-  -c, --cluster string           Name or ID of the cluster to edit.
-      --expiration-time string   Specific time when cluster should expire (RFC3339). Only one of expiration-time / expiration may be used.
-      --expiration duration      Expire cluster after a relative duration like 2h, 8h, 72h. Only one of expiration-time / expiration may be used.
-      --compute-nodes int        Number of worker nodes to provision per zone. Single zone clusters need at least 4 nodes, while multizone clusters need at least 9 nodes (3 per zone) for resiliency.
-      --private                  Restrict master API endpoint to direct, private connectivity.
-      --enable-cluster-admins    Enable the cluster-admins role for your cluster.
-  -h, --help                     help for cluster
+  -c, --cluster string          Name or ID of the cluster to edit.
+      --compute-nodes int       Number of worker nodes to provision per zone. Single zone clusters need at least 4 nodes, while multizone clusters need at least 9 nodes (3 per zone) for resiliency.
+      --private                 Restrict master API endpoint to direct, private connectivity.
+      --enable-cluster-admins   Enable the cluster-admins role for your cluster.
+  -h, --help                    help for cluster
 ```
 
 ### Options inherited from parent commands
 
 ```
-      --debug     Enable debug mode.
-  -v, --v Level   log level for V logs
+      --debug         Enable debug mode.
+  -i, --interactive   Enable interactive mode.
+  -v, --v Level       log level for V logs
 ```
 
 ### SEE ALSO

--- a/docs/moactl_edit_ingress.md
+++ b/docs/moactl_edit_ingress.md
@@ -35,8 +35,9 @@ moactl edit ingress [flags]
 ### Options inherited from parent commands
 
 ```
-      --debug     Enable debug mode.
-  -v, --v Level   log level for V logs
+      --debug         Enable debug mode.
+  -i, --interactive   Enable interactive mode.
+  -v, --v Level       log level for V logs
 ```
 
 ### SEE ALSO


### PR DESCRIPTION
In interactive edit mode, if a cli flag is not supplied, the default value is set directly from the cluster itself.

Demo: https://asciinema.org/a/bkaHd59KW71GUGp6bCdCIDtIj
