### PR TITLE
addons: Add list and create commands for add-ons

### DIFF
--- a/cmd/create/addon/cmd.go
+++ b/cmd/create/addon/cmd.go
@@ -1,0 +1,140 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package addon
+
+import (
+	"os"
+
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	"github.com/spf13/cobra"
+
+	"github.com/openshift/moactl/pkg/aws"
+	clusterprovider "github.com/openshift/moactl/pkg/cluster"
+	"github.com/openshift/moactl/pkg/logging"
+	"github.com/openshift/moactl/pkg/ocm"
+	rprtr "github.com/openshift/moactl/pkg/reporter"
+)
+
+var args struct {
+	clusterKey string
+}
+
+var Cmd = &cobra.Command{
+	Use:     "addon",
+	Aliases: []string{"addons", "add-on", "add-ons"},
+	Short:   "Install add-ons on cluster",
+	Long:    "Install Red Hat managed add-ons on a cluster",
+	Example: `  # Add the CodeReady Workspaces add-on installation to the cluster
+  moactl create addon --cluster=mycluster codeready-workspaces`,
+	Run: run,
+}
+
+func init() {
+	flags := Cmd.Flags()
+
+	flags.StringVarP(
+		&args.clusterKey,
+		"cluster",
+		"c",
+		"",
+		"Name or ID of the cluster to add the IdP to (required).",
+	)
+	Cmd.MarkFlagRequired("cluster")
+}
+
+func run(_ *cobra.Command, argv []string) {
+	reporter := rprtr.CreateReporterOrExit()
+	logger := logging.CreateLoggerOrExit(reporter)
+
+	// Check command line arguments:
+	if len(argv) != 1 {
+		reporter.Errorf("Expected exactly one command line parameters containing the identifier of the add-on.")
+		os.Exit(1)
+	}
+
+	addOnID := argv[0]
+	if addOnID == "" {
+		reporter.Errorf("Add-on ID is required.")
+		os.Exit(1)
+	}
+
+	// Check that the cluster key (name, identifier or external identifier) given by the user
+	// is reasonably safe so that there is no risk of SQL injection:
+	clusterKey := args.clusterKey
+	if !ocm.IsValidClusterKey(clusterKey) {
+		reporter.Errorf(
+			"Cluster name, identifier or external identifier '%s' isn't valid: it "+
+				"must contain only letters, digits, dashes and underscores",
+			clusterKey,
+		)
+		os.Exit(1)
+	}
+
+	// Create the AWS client:
+	awsClient, err := aws.NewClient().
+		Logger(logger).
+		Build()
+	if err != nil {
+		reporter.Errorf("Failed to create AWS client: %v", err)
+		os.Exit(1)
+	}
+
+	awsCreator, err := awsClient.GetCreator()
+	if err != nil {
+		reporter.Errorf("Failed to get AWS creator: %v", err)
+		os.Exit(1)
+	}
+
+	// Create the client for the OCM API:
+	ocmConnection, err := ocm.NewConnection().
+		Logger(logger).
+		Build()
+	if err != nil {
+		reporter.Errorf("Failed to create OCM connection: %v", err)
+		os.Exit(1)
+	}
+	defer func() {
+		err = ocmConnection.Close()
+		if err != nil {
+			reporter.Errorf("Failed to close OCM connection: %v", err)
+		}
+	}()
+
+	// Get the client for the OCM collection of clusters:
+	clustersCollection := ocmConnection.ClustersMgmt().V1().Clusters()
+
+	// Try to find the cluster:
+	reporter.Debugf("Loading cluster '%s'", clusterKey)
+	cluster, err := ocm.GetCluster(clustersCollection, clusterKey, awsCreator.ARN)
+	if err != nil {
+		reporter.Errorf("Failed to get cluster '%s': %v", clusterKey, err)
+		os.Exit(1)
+	}
+
+	if cluster.State() != cmv1.ClusterStateReady {
+		reporter.Errorf("Cluster '%s' is not yet ready", clusterKey)
+		os.Exit(1)
+	}
+
+	reporter.Debugf("Installing add-on '%s' on cluster '%s'", addOnID, clusterKey)
+	err = clusterprovider.InstallAddOn(clustersCollection, clusterKey, awsCreator.ARN, addOnID)
+	if err != nil {
+		reporter.Errorf("Failed to add add-on installation '%s' for cluster '%s': %s", addOnID, clusterKey, err)
+		os.Exit(1)
+	}
+	reporter.Debugf("Installed add-on '%s' on cluster '%s'", addOnID, clusterKey)
+}

--- a/cmd/create/cmd.go
+++ b/cmd/create/cmd.go
@@ -19,6 +19,7 @@ package create
 import (
 	"github.com/spf13/cobra"
 
+	"github.com/openshift/moactl/cmd/create/addon"
 	"github.com/openshift/moactl/cmd/create/cluster"
 	"github.com/openshift/moactl/cmd/create/idp"
 	"github.com/openshift/moactl/cmd/create/ingress"
@@ -34,6 +35,7 @@ var Cmd = &cobra.Command{
 }
 
 func init() {
+	Cmd.AddCommand(addon.Cmd)
 	Cmd.AddCommand(cluster.Cmd)
 	Cmd.AddCommand(idp.Cmd)
 	Cmd.AddCommand(ingress.Cmd)

--- a/cmd/list/addon/cmd.go
+++ b/cmd/list/addon/cmd.go
@@ -1,0 +1,138 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package addon
+
+import (
+	"fmt"
+	"os"
+	"text/tabwriter"
+
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	"github.com/spf13/cobra"
+
+	"github.com/openshift/moactl/pkg/aws"
+	"github.com/openshift/moactl/pkg/logging"
+	"github.com/openshift/moactl/pkg/ocm"
+	rprtr "github.com/openshift/moactl/pkg/reporter"
+)
+
+var args struct {
+	clusterKey string
+}
+
+var Cmd = &cobra.Command{
+	Use:     "addons",
+	Aliases: []string{"addon", "add-ons", "add-on"},
+	Short:   "List add-on installations",
+	Long:    "List add-ons installed on a cluster.",
+	Example: `  # List all add-on installations on a cluster named "mycluster"
+  moactl list addons --cluster=mycluster`,
+	Run: run,
+}
+
+func init() {
+	flags := Cmd.Flags()
+
+	flags.StringVarP(
+		&args.clusterKey,
+		"cluster",
+		"c",
+		"",
+		"Name or ID of the cluster to list the add-ons of (required).",
+	)
+	Cmd.MarkFlagRequired("cluster")
+}
+
+func run(_ *cobra.Command, _ []string) {
+	reporter := rprtr.CreateReporterOrExit()
+	logger := logging.CreateLoggerOrExit(reporter)
+
+	// Check that the cluster key (name, identifier or external identifier) given by the user
+	// is reasonably safe so that there is no risk of SQL injection:
+	clusterKey := args.clusterKey
+	if !ocm.IsValidClusterKey(clusterKey) {
+		reporter.Errorf(
+			"Cluster name, identifier or external identifier '%s' isn't valid: it "+
+				"must contain only letters, digits, dashes and underscores",
+			clusterKey,
+		)
+		os.Exit(1)
+	}
+
+	// Create the AWS client:
+	awsClient, err := aws.NewClient().
+		Logger(logger).
+		Build()
+	if err != nil {
+		reporter.Errorf("Failed to create AWS client: %v", err)
+		os.Exit(1)
+	}
+
+	awsCreator, err := awsClient.GetCreator()
+	if err != nil {
+		reporter.Errorf("Failed to get AWS creator: %v", err)
+		os.Exit(1)
+	}
+
+	// Create the client for the OCM API:
+	ocmConnection, err := ocm.NewConnection().
+		Logger(logger).
+		Build()
+	if err != nil {
+		reporter.Errorf("Failed to create OCM connection: %v", err)
+		os.Exit(1)
+	}
+	defer func() {
+		err = ocmConnection.Close()
+		if err != nil {
+			reporter.Errorf("Failed to close OCM connection: %v", err)
+		}
+	}()
+
+	// Try to find the cluster:
+	reporter.Debugf("Loading cluster '%s'", clusterKey)
+	cluster, err := ocm.GetCluster(ocmConnection.ClustersMgmt().V1().Clusters(), clusterKey, awsCreator.ARN)
+	if err != nil {
+		reporter.Errorf("Failed to get cluster '%s': %v", clusterKey, err)
+		os.Exit(1)
+	}
+
+	if cluster.State() != cmv1.ClusterStateReady {
+		reporter.Errorf("Cluster '%s' is not yet ready", clusterKey)
+		os.Exit(1)
+	}
+
+	// Load any existing Add-Ons for this cluster
+	reporter.Debugf("Loading add-ons installations for cluster '%s'", clusterKey)
+	clusterAddOns, err := ocm.GetClusterAddOns(ocmConnection, cluster.ID())
+	if err != nil {
+		reporter.Errorf("Failed to get add-ons for cluster '%s': %v", clusterKey, err)
+		os.Exit(1)
+	}
+
+	if len(clusterAddOns) == 0 {
+		reporter.Infof("There are no add-ons installed on cluster '%s'", clusterKey)
+	}
+
+	// Create the writer that will be used to print the tabulated results:
+	writer := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintf(writer, "ID\t\tNAME\t\tSTATE\n")
+	for _, clusterAddOn := range clusterAddOns {
+		fmt.Fprintf(writer, "%s\t\t%s\t\t%s\n", clusterAddOn.ID, clusterAddOn.Name, clusterAddOn.State)
+	}
+	writer.Flush()
+}

--- a/cmd/list/cmd.go
+++ b/cmd/list/cmd.go
@@ -19,6 +19,7 @@ package list
 import (
 	"github.com/spf13/cobra"
 
+	"github.com/openshift/moactl/cmd/list/addon"
 	"github.com/openshift/moactl/cmd/list/cluster"
 	"github.com/openshift/moactl/cmd/list/idp"
 	"github.com/openshift/moactl/cmd/list/ingress"
@@ -32,6 +33,7 @@ var Cmd = &cobra.Command{
 }
 
 func init() {
+	Cmd.AddCommand(addon.Cmd)
 	Cmd.AddCommand(cluster.Cmd)
 	Cmd.AddCommand(idp.Cmd)
 	Cmd.AddCommand(ingress.Cmd)

--- a/docs/moactl_create.md
+++ b/docs/moactl_create.md
@@ -23,6 +23,7 @@ Create a resource from stdin
 ### SEE ALSO
 
 * [moactl](moactl.md)	 - 
+* [moactl create addon](moactl_create_addon.md)	 - Install add-ons on cluster
 * [moactl create cluster](moactl_create_cluster.md)	 - Create cluster
 * [moactl create idp](moactl_create_idp.md)	 - Add IDP for cluster
 * [moactl create ingress](moactl_create_ingress.md)	 - Add Ingress to cluster

--- a/docs/moactl_create_addon.md
+++ b/docs/moactl_create_addon.md
@@ -1,0 +1,38 @@
+## moactl create addon
+
+Install add-ons on cluster
+
+### Synopsis
+
+Install Red Hat managed add-ons on a cluster
+
+```
+moactl create addon [flags]
+```
+
+### Examples
+
+```
+  # Add the CodeReady Workspaces add-on installation to the cluster
+  moactl create addon --cluster=mycluster codeready-workspaces
+```
+
+### Options
+
+```
+  -c, --cluster string   Name or ID of the cluster to add the IdP to (required).
+  -h, --help             help for addon
+```
+
+### Options inherited from parent commands
+
+```
+      --debug         Enable debug mode.
+  -i, --interactive   Enable interactive mode.
+  -v, --v Level       log level for V logs
+```
+
+### SEE ALSO
+
+* [moactl create](moactl_create.md)	 - Create a resource from stdin
+

--- a/docs/moactl_list.md
+++ b/docs/moactl_list.md
@@ -22,6 +22,7 @@ List all resources of a specific type
 ### SEE ALSO
 
 * [moactl](moactl.md)	 - 
+* [moactl list addons](moactl_list_addons.md)	 - List add-on installations
 * [moactl list clusters](moactl_list_clusters.md)	 - List clusters
 * [moactl list idps](moactl_list_idps.md)	 - List cluster IDPs
 * [moactl list ingresses](moactl_list_ingresses.md)	 - List cluster Ingresses

--- a/docs/moactl_list_addons.md
+++ b/docs/moactl_list_addons.md
@@ -1,0 +1,37 @@
+## moactl list addons
+
+List add-on installations
+
+### Synopsis
+
+List add-ons installed on a cluster.
+
+```
+moactl list addons [flags]
+```
+
+### Examples
+
+```
+  # List all add-on installations on a cluster named "mycluster"
+  moactl list addons --cluster=mycluster
+```
+
+### Options
+
+```
+  -c, --cluster string   Name or ID of the cluster to list the add-ons of (required).
+  -h, --help             help for addons
+```
+
+### Options inherited from parent commands
+
+```
+      --debug     Enable debug mode.
+  -v, --v Level   log level for V logs
+```
+
+### SEE ALSO
+
+* [moactl list](moactl_list.md)	 - List all resources of a specific type
+

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -240,6 +240,27 @@ func DeleteCluster(client *cmv1.ClustersClient, clusterKey string, creatorARN st
 	return nil
 }
 
+func InstallAddOn(client *cmv1.ClustersClient, clusterKey string, creatorARN string, addOnID string) error {
+	cluster, err := GetCluster(client, clusterKey, creatorARN)
+	if err != nil {
+		return err
+	}
+
+	addOnInstallation, err := cmv1.NewAddOnInstallation().
+		Addon(cmv1.NewAddOn().ID(addOnID)).
+		Build()
+	if err != nil {
+		return err
+	}
+
+	_, err = client.Cluster(cluster.ID()).Addons().Add().Body(addOnInstallation).Send()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func createClusterSpec(config Spec, awsClient aws.Client) (*cmv1.Cluster, error) {
 	reporter, err := rprtr.New().
 		Build()

--- a/pkg/ocm/helpers.go
+++ b/pkg/ocm/helpers.go
@@ -23,6 +23,8 @@ import (
 	"regexp"
 	"time"
 
+	sdk "github.com/openshift-online/ocm-sdk-go"
+	amsv1 "github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1"
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	errors "github.com/zgalor/weberr"
 
@@ -128,6 +130,103 @@ func GetLogs(client *cmv1.ClustersClient, clusterID string, tail int) (logs *cmv
 	}
 
 	return response.Body(), nil
+}
+
+type ClusterAddOn struct {
+	ID        string
+	Name      string
+	State     string
+	Available bool
+}
+
+// Get all add-ons available for a cluster
+func GetClusterAddOns(connection *sdk.Connection, clusterID string) ([]*ClusterAddOn, error) {
+	// Get organization ID (used to get add-on quotas)
+	acctResponse, err := connection.AccountsMgmt().V1().CurrentAccount().
+		Get().
+		Send()
+	if err != nil {
+		return nil, fmt.Errorf("Failed to get current account: %s", err)
+	}
+	organization := acctResponse.Body().Organization().ID()
+
+	// Get a list of add-on quotas for the current organization
+	resourceQuotasResponse, err := connection.AccountsMgmt().V1().Organizations().
+		Organization(organization).
+		ResourceQuota().
+		List().
+		Search("resource_type='addon'").
+		Page(1).
+		Size(-1).
+		Send()
+	if err != nil {
+		return nil, fmt.Errorf("Failed to get add-ons: %v", err)
+	}
+	resourceQuotas := resourceQuotasResponse.Items()
+
+	// Get complete list of enabled add-ons
+	addOnsResponse, err := connection.ClustersMgmt().V1().Addons().
+		List().
+		Search("enabled='t'").
+		Page(1).
+		Size(-1).
+		Send()
+	if err != nil {
+		return nil, fmt.Errorf("Failed to get add-ons: %v", err)
+	}
+	addOns := addOnsResponse.Items()
+
+	// Get add-ons already installed on cluster
+	addOnInstallationsResponse, err := connection.ClustersMgmt().V1().Clusters().
+		Cluster(clusterID).
+		Addons().
+		List().
+		Page(1).
+		Size(-1).
+		Send()
+	if err != nil {
+		return nil, fmt.Errorf("Failed to get add-on installations for cluster '%s': %v", clusterID, err)
+	}
+	addOnInstallations := addOnInstallationsResponse.Items()
+
+	var clusterAddOns []*ClusterAddOn
+
+	// Populate add-on installations with all add-on metadata
+	addOns.Each(func(addOn *cmv1.AddOn) bool {
+		clusterAddOn := ClusterAddOn{
+			ID:        addOn.ID(),
+			Name:      addOn.Name(),
+			State:     "not installed",
+			Available: addOn.ResourceCost() == 0,
+		}
+
+		// Only display add-ons for which the org has quota
+		resourceQuotas.Each(func(resourceQuota *amsv1.ResourceQuota) bool {
+			if addOn.ResourceName() == resourceQuota.ResourceName() {
+				clusterAddOn.Available = float64(resourceQuota.Allowed()) > addOn.ResourceCost()
+			}
+			return true
+		})
+
+		// Get the state of add-on installations on the cluster
+		addOnInstallations.Each(func(addOnInstallation *cmv1.AddOnInstallation) bool {
+			if addOn.ID() == addOnInstallation.Addon().ID() {
+				clusterAddOn.State = string(addOnInstallation.State())
+				if clusterAddOn.State == "" {
+					clusterAddOn.State = string(cmv1.AddOnInstallationStateInstalling)
+				}
+			}
+			return true
+		})
+
+		// Only display add-ons that meet the above criteria
+		if clusterAddOn.Available {
+			clusterAddOns = append(clusterAddOns, &clusterAddOn)
+		}
+		return true
+	})
+
+	return clusterAddOns, nil
 }
 
 func PollLogs(client *cmv1.ClustersClient, clusterID string,


### PR DESCRIPTION
When listing add-ons for a cluster, we show the list of enabled add-ons
that the current organization has quota for, as well as those already
installed in the cluster. From this list the user can use the ID to
manually install add-ons using the `create` command.

Since there can be confusion regarding the spelling of add-ons, I've
added aliases for "addon", "add-on", as well as their plurals. Also,
since the user is not "creating" and add-on, we can use the alias "add"
instead of "create", although both work similarly.

Demo: https://asciinema.org/a/rlF6g0IujtKZNwT1s1d3B6f0u