### PR TITLE
create-idp: Fallback to interactive mode

### DIFF
--- a/cmd/create/idp/cmd.go
+++ b/cmd/create/idp/cmd.go
@@ -298,7 +298,7 @@ func run(cmd *cobra.Command, _ []string) {
 
 	// Grab all the IDP information interactively if necessary
 	idpType := args.idpType
-	if interactive.Enabled() {
+	if interactive.Enabled() || idpType == "" {
 		if idpType == "" {
 			idpType = validIdps[0]
 		}

--- a/cmd/create/idp/github.go
+++ b/cmd/create/idp/github.go
@@ -46,7 +46,7 @@ func buildGithubIdp(cmd *cobra.Command,
 		restrictType = "teams"
 	}
 
-	if interactive.Enabled() && restrictType == "" {
+	if interactive.Enabled() || restrictType == "" {
 		restrictType, err = interactive.GetOption(interactive.Input{
 			Question: "Restrict to members of",
 			Help:     "GitHub authentication lets you use either GitHub organizations or GitHub teams to restrict access.",
@@ -59,7 +59,7 @@ func buildGithubIdp(cmd *cobra.Command,
 		}
 	}
 
-	if interactive.Enabled() {
+	if interactive.Enabled() || (organizations == "" && teams == "") {
 		if restrictType == "organizations" {
 			organizations, err = interactive.GetString(interactive.Input{
 				Question: "GitHub organizations",


### PR DESCRIPTION
If required fields are not sent as flags, we should fall back to
interactive mode to gather necessary data.