### PR TITLE
logs improvements

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -27,6 +27,7 @@ import (
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	"github.com/spf13/cobra"
 
+	clusterdescribe "github.com/openshift/moactl/cmd/describe/cluster"
 	clusterlogs "github.com/openshift/moactl/cmd/logs/cluster"
 
 	"github.com/openshift/moactl/pkg/aws"
@@ -448,6 +449,8 @@ func run(cmd *cobra.Command, _ []string) {
 			clusterName,
 		)
 	}
+
+	clusterdescribe.Cmd.Run(cmd, []string{clusterID})
 }
 
 // Validate OpenShift versions

--- a/cmd/logs/cluster/cmd.go
+++ b/cmd/logs/cluster/cmd.go
@@ -77,9 +77,13 @@ func init() {
 	)
 }
 
-func run(_ *cobra.Command, argv []string) {
+func run(cmd *cobra.Command, argv []string) {
 	reporter := rprtr.CreateReporterOrExit()
 	logger := logging.CreateLoggerOrExit(reporter)
+
+	// Determine whether the user wants to watch logs streaming.
+	// We check the flag value this way to allow other commands to watch logs
+	watch := cmd.Flags().Lookup("watch").Value.String() == "true"
 
 	// Check command line arguments:
 	clusterKey := args.clusterKey
@@ -151,7 +155,7 @@ func run(_ *cobra.Command, argv []string) {
 		os.Exit(0)
 	}
 
-	if cluster.State() == cmv1.ClusterStatePending && !args.watch {
+	if cluster.State() == cmv1.ClusterStatePending && !watch {
 		reporter.Warnf("Logs for cluster '%s' are not available yet", clusterKey)
 		os.Exit(1)
 	}
@@ -168,7 +172,7 @@ func run(_ *cobra.Command, argv []string) {
 			os.Exit(0)
 		} else if errors.GetType(err) == errors.NotFound {
 			reporter.Warnf("Logs for cluster '%s' are not available yet", clusterKey)
-			if args.watch {
+			if watch {
 				reporter.Warnf("Waiting...")
 			}
 		} else {
@@ -178,7 +182,7 @@ func run(_ *cobra.Command, argv []string) {
 	}
 	printLog(logs)
 
-	if args.watch {
+	if watch {
 		// Poll for changing logs:
 		response, err := ocm.PollLogs(clustersCollection, cluster.ID(), printLogCallback)
 		if err != nil {

--- a/docs/moactl_create_cluster.md
+++ b/docs/moactl_create_cluster.md
@@ -35,6 +35,8 @@ moactl create cluster [flags]
       --pod-cidr ipNet                Block of IP addresses from which Pod IP addresses are allocated, for example "10.128.0.0/14".
       --host-prefix int               Subnet prefix length to assign to each individual node. For example, if host prefix is set to "23", then each node is assigned a /23 subnet out of the given CIDR.
       --private                       Restrict master API endpoint and application routes to direct, private connectivity.
+                                      
+      --watch                         Watch cluster installation logs.
   -h, --help                          help for cluster
 ```
 


### PR DESCRIPTION
* logs: Detach log watch when cluster is Ready
* create-cluster: Allow user to watch cluster installation logs

Depends on https://gitlab.cee.redhat.com/service/uhc-clusters-service/-/merge_requests/1989