### PR TITLE
[WIP] Allow selection of AWS profile during initalization

### DIFF
--- a/cmd/initialize/cmd.go
+++ b/cmd/initialize/cmd.go
@@ -39,6 +39,7 @@ import (
 var args struct {
 	region      string
 	deleteStack bool
+	profile     string
 }
 
 var Cmd = &cobra.Command{
@@ -73,6 +74,14 @@ func init() {
 		"Deletes stack template applied to your AWS account during the 'init' command.\n",
 	)
 
+	flags.StringVarP(
+		&args.profile,
+		"profile",
+		 "p",
+		"default",
+		"AWS credentials profile to use",
+	)
+
 	// Force-load all flags from `login` into `init`
 	flags.AddFlagSet(login.Cmd.Flags())
 }
@@ -92,6 +101,7 @@ func run(cmd *cobra.Command, argv []string) {
 	client, err := aws.NewClient().
 		Logger(logger).
 		Region(region).
+		Profile(args.profile).
 		Build()
 	if err != nil {
 		reporter.Errorf("Error creating AWS client: %v", err)

--- a/pkg/aws/client.go
+++ b/pkg/aws/client.go
@@ -66,6 +66,7 @@ type Client interface {
 type ClientBuilder struct {
 	logger *logrus.Logger
 	region *string
+	profile *string
 }
 
 type awsClient struct {
@@ -94,6 +95,11 @@ func (b *ClientBuilder) Region(value string) *ClientBuilder {
 	return b
 }
 
+func (b *ClientBuilder) Profile(value string) *ClientBuilder {
+	b.profile = aws.String(value)
+	return b
+}
+
 // Build uses the information stored in the builder to build a new AWS client.
 func (b *ClientBuilder) Build() (result Client, err error) {
 	// Check parameters:
@@ -113,6 +119,7 @@ func (b *ClientBuilder) Build() (result Client, err error) {
 	// Create the AWS session:
 	sess, err := session.NewSessionWithOptions(session.Options{
 		SharedConfigState: session.SharedConfigEnable,
+		Profile: *b.profile,
 		Config: aws.Config{
 			Region: b.region,
 			// MaxRetries to limit the number of attempts on failed API calls


### PR DESCRIPTION
Currently, there is no way to specify a credentials profile from `~/.aws/credentials` to use. This PR adds `--profile` to `moactl init` to allow for that selection

Usage:
`moactl init --profile my-moa-creds`