### PR TITLE
Validate permissions in the AWS client region

### DIFF
--- a/pkg/aws/client.go
+++ b/pkg/aws/client.go
@@ -354,7 +354,7 @@ func (c *awsClient) ValidateSCP() (bool, error) {
 	scpPolicyPath := "templates/policies/osd_scp_policy.json"
 	requiredPermissions := []string{}
 	sParams := &SimulateParams{
-		Region: region,
+		Region: *c.awsSession.Config.Region,
 	}
 
 	for group := range permissions {

--- a/pkg/aws/permissions.go
+++ b/pkg/aws/permissions.go
@@ -50,9 +50,6 @@ const (
 
 	// PermissionDeleteNetworking is a set of permissions required when the installer destroys networking resources.
 	PermissionDeleteNetworking PermissionGroup = "delete-networking"
-
-	// AWS Region
-	region = "eu-central-1"
 )
 
 // Permissions list of permissions required to install a cluster


### PR DESCRIPTION
Currently permissions are validation in a single region, this PR changes that to use the region set in the client.