### PR TITLE
create-cluster: Set compute node defaults based on AZ

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -112,7 +112,7 @@ func init() {
 		&args.expirationDuration,
 		"expiration",
 		0,
-		"Expire cluster after a relative duration like 2h, 8h, 72h. Only one of expiration-time / expiration may be used.\n",
+		"Expire cluster after a relative duration like 2h, 8h, 72h. Only one of expiration-time / expiration may be used.",
 	)
 	// Cluster expiration is not supported in production
 	flags.MarkHidden("expiration-time")
@@ -128,9 +128,9 @@ func init() {
 	flags.IntVar(
 		&args.computeNodes,
 		"compute-nodes",
-		0,
+		4,
 		"Number of worker nodes to provision per zone. Single zone clusters need at least 4 nodes, "+
-			"while multizone clusters need at least 9 nodes (3 per zone) for resiliency.\n",
+			"multizone clusters need at least 9 nodes.",
 	)
 
 	flags.IPNetVar(
@@ -306,6 +306,10 @@ func run(cmd *cobra.Command, _ []string) {
 
 	// Compute nodes:
 	computeNodes := args.computeNodes
+	// Compute node requirements for multi-AZ clusters are higher
+	if multiAZ && !cmd.Flags().Changed("compute-nodes") {
+		computeNodes = 9
+	}
 	if interactive.Enabled() {
 		computeNodes, err = interactive.GetInt(interactive.Input{
 			Question: "Compute nodes",

--- a/docs/moactl_create_cluster.md
+++ b/docs/moactl_create_cluster.md
@@ -28,8 +28,7 @@ moactl create cluster [flags]
       --version string                Version of OpenShift that will be used to install the cluster, for example "4.3.10"
       --multi-az                      Deploy to multiple data centers.
       --compute-machine-type string   Instance type for the compute nodes. Determines the amount of memory and vCPU allocated to each compute node.
-      --compute-nodes int             Number of worker nodes to provision per zone. Single zone clusters need at least 4 nodes, while multizone clusters need at least 9 nodes (3 per zone) for resiliency.
-                                      
+      --compute-nodes int             Number of worker nodes to provision per zone. Single zone clusters need at least 4 nodes, multizone clusters need at least 9 nodes. (default 4)
       --machine-cidr ipNet            Block of IP addresses used by OpenShift while installing the cluster, for example "10.0.0.0/16".
       --service-cidr ipNet            Block of IP addresses for services, for example "172.30.0.0/16".
       --pod-cidr ipNet                Block of IP addresses from which Pod IP addresses are allocated, for example "10.128.0.0/14".


### PR DESCRIPTION
To avoid the API from rejecting a cluster creation request based on the
number of nodes, we set a reasonable default: 4 nodes for single AZ
clusters and 9 for multi AZ clusters.