### PR TITLE
addons: Remove global list of add-ons

### DIFF
--- a/docs/moactl_list_addons.md
+++ b/docs/moactl_list_addons.md
@@ -13,9 +13,6 @@ moactl list addons [flags]
 ### Examples
 
 ```
-  # List all add-ons
-  moactl list addons
-
   # List all add-on installations on a cluster named "mycluster"
   moactl list addons --cluster=mycluster
 ```

--- a/pkg/ocm/helpers.go
+++ b/pkg/ocm/helpers.go
@@ -112,18 +112,6 @@ func GetUsers(client *cmv1.ClustersClient, clusterID string, group string) ([]*c
 	return response.Items().Slice(), nil
 }
 
-func GetAddOns(client *cmv1.AddOnsClient) ([]*cmv1.AddOn, error) {
-	response, err := client.List().
-		Search("enabled='t'").
-		Page(1).
-		Size(-1).
-		Send()
-	if err != nil {
-		return nil, fmt.Errorf("Failed to get add-ons: %v", err)
-	}
-	return response.Items().Slice(), nil
-}
-
 func GetAddOn(client *cmv1.AddOnsClient, id string) (*cmv1.AddOn, error) {
 	addOn, err := client.Addon(id).Get().Send()
 	if err != nil {


### PR DESCRIPTION
We should not show the entire list of add-ons in our database. Instead,
we should just gate the list of add-ons by cluster and take into account
the organization's quota.