### PR TITLE
delete-user: Fix confirmation output

### DIFF
--- a/cmd/dlt/user/cmd.go
+++ b/cmd/dlt/user/cmd.go
@@ -158,9 +158,8 @@ func run(_ *cobra.Command, _ []string) {
 		os.Exit(1)
 	}
 
-	if !confirm.Confirm("delete users %s from cluster %s",
-		strings.Join([]string{clusterAdmins, dedicatedAdmins}, ","),
-		clusterKey) {
+	allUsers := strings.Join([]string{clusterAdmins, dedicatedAdmins}, ",")
+	if !confirm.Confirm("delete users %s from cluster %s", strings.Trim(allUsers, ","), clusterKey) {
 		os.Exit(0)
 	}
 


### PR DESCRIPTION
When deleting a single user which is a cluster-admin as well as a dedicated-admin, the confirmation message displays different format of comma-separated users (",travi" and "travi,") for either categories.

While deleting dedicated-admin user:
```
$ moactl delete user -c rbt-moa-test --dedicated-admins travi
 ? Are you sure you want to delete users ,travi from cluster rbt-moa-test? Yes
```
While deleting cluster-admin user:
```
$ moactl delete user -c rbt-moa-test --cluster-admins travi
 ? Are you sure you want to delete users travi, from cluster rbt-moa-test? Yes
```
This patch fixes it so that commas are trimmed on output.