### PR TITLE
Log improvements

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -27,6 +27,7 @@ import (
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	"github.com/spf13/cobra"
 
+	clusterdescribe "github.com/openshift/moactl/cmd/describe/cluster"
 	installLogs "github.com/openshift/moactl/cmd/logs/install"
 
 	"github.com/openshift/moactl/pkg/aws"
@@ -461,6 +462,8 @@ func run(cmd *cobra.Command, _ []string) {
 			clusterName,
 		)
 	}
+
+	clusterdescribe.Cmd.Run(cmd, []string{cluster.ID()})
 }
 
 // Validate OpenShift versions

--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -27,6 +27,8 @@ import (
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	"github.com/spf13/cobra"
 
+	installLogs "github.com/openshift/moactl/cmd/logs/install"
+
 	"github.com/openshift/moactl/pkg/aws"
 	clusterprovider "github.com/openshift/moactl/pkg/cluster"
 	"github.com/openshift/moactl/pkg/interactive"
@@ -39,6 +41,9 @@ import (
 )
 
 var args struct {
+	// Watch logs during cluster installation
+	watch bool
+
 	// Basic options
 	private            bool
 	multiAZ            bool
@@ -171,6 +176,13 @@ func init() {
 		"private",
 		false,
 		"Restrict master API endpoint and application routes to direct, private connectivity.",
+	)
+
+	flags.BoolVar(
+		&args.watch,
+		"watch",
+		false,
+		"Watch cluster installation logs.",
 	)
 }
 
@@ -433,13 +445,22 @@ func run(cmd *cobra.Command, _ []string) {
 
 	reporter.Infof("Cluster '%s' has been created.", clusterName)
 	reporter.Infof(
-		"Once the cluster is 'Ready' you will need to add an Identity Provider " +
-			"and define the list of cluster administrators. See 'moactl create idp --help' " +
-			"and 'moactl create user --help' for more information.")
-	reporter.Infof(
-		"To determine when your cluster is Ready, run 'moactl describe cluster %s'.",
-		clusterName,
-	)
+		"Once the cluster is installed you will need to add an Identity Provider " +
+			"before you can login into the cluster. See 'moactl create idp --help' " +
+			"for more information.")
+
+	if args.watch {
+		installLogs.Cmd.Run(cmd, []string{cluster.ID()})
+	} else {
+		reporter.Infof(
+			"To determine when your cluster is Ready, run 'moactl describe cluster -c %s'.",
+			clusterName,
+		)
+		reporter.Infof(
+			"To watch your cluster installation logs, run 'moactl logs install -c %s --watch'.",
+			clusterName,
+		)
+	}
 }
 
 // Validate OpenShift versions

--- a/docs/moactl_create_cluster.md
+++ b/docs/moactl_create_cluster.md
@@ -34,6 +34,7 @@ moactl create cluster [flags]
       --pod-cidr ipNet                Block of IP addresses from which Pod IP addresses are allocated, for example "10.128.0.0/14".
       --host-prefix int               Subnet prefix length to assign to each individual node. For example, if host prefix is set to "23", then each node is assigned a /23 subnet out of the given CIDR.
       --private                       Restrict master API endpoint and application routes to direct, private connectivity.
+      --watch                         Watch cluster installation logs.
   -h, --help                          help for cluster
 ```
 

--- a/docs/moactl_delete_cluster.md
+++ b/docs/moactl_delete_cluster.md
@@ -25,6 +25,7 @@ moactl delete cluster [ID|NAME] [flags]
 ```
   -c, --cluster string   Name or ID of the cluster to delete.
   -h, --help             help for cluster
+      --watch            Watch cluster uninstallation logs.
 ```
 
 ### Options inherited from parent commands

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -226,18 +226,18 @@ func UpdateCluster(client *cmv1.ClustersClient, clusterKey string, creatorARN st
 	return nil
 }
 
-func DeleteCluster(client *cmv1.ClustersClient, clusterKey string, creatorARN string) error {
+func DeleteCluster(client *cmv1.ClustersClient, clusterKey string, creatorARN string) (*cmv1.Cluster, error) {
 	cluster, err := GetCluster(client, clusterKey, creatorARN)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	_, err = client.Cluster(cluster.ID()).Delete().Send()
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	return nil
+	return cluster, nil
 }
 
 func InstallAddOn(client *cmv1.ClustersClient, clusterKey string, creatorARN string, addOnID string) error {

--- a/pkg/ocm/helpers.go
+++ b/pkg/ocm/helpers.go
@@ -216,3 +216,11 @@ func GetClusterAddOns(connection *sdk.Connection, clusterID string) ([]*ClusterA
 
 	return clusterAddOns, nil
 }
+
+func GetClusterState(client *cmv1.ClustersClient, clusterID string) (cmv1.ClusterState, error) {
+	response, err := client.Cluster(clusterID).Status().Get().Send()
+	if err != nil || response.Body() == nil {
+		return cmv1.ClusterState(""), err
+	}
+	return response.Body().State(), nil
+}

--- a/pkg/ocm/logs.go
+++ b/pkg/ocm/logs.go
@@ -26,6 +26,8 @@ import (
 	errors "github.com/zgalor/weberr"
 )
 
+const interval = 15 * time.Second
+
 func GetInstallLogs(client *cmv1.ClustersClient, clusterID string, tail int) (logs *cmv1.Log, err error) {
 	logsClient := client.Cluster(clusterID).Logs().Install()
 	response, err := logsClient.Get().
@@ -68,7 +70,7 @@ func PollInstallLogs(client *cmv1.ClustersClient, clusterID string,
 	logsClient := client.Cluster(clusterID).Logs().Install()
 	response, err := logsClient.Poll().
 		Parameter("tail", 100).
-		Interval(5 * time.Second).
+		Interval(interval).
 		Predicate(cb).
 		StartContext(ctx)
 	if err != nil {
@@ -92,7 +94,7 @@ func PollUninstallLogs(client *cmv1.ClustersClient, clusterID string,
 	logsClient := client.Cluster(clusterID).Logs().Uninstall()
 	response, err := logsClient.Poll().
 		Parameter("tail", 100).
-		Interval(5 * time.Second).
+		Interval(interval).
 		Predicate(cb).
 		StartContext(ctx)
 	if err != nil {


### PR DESCRIPTION
There are 4 commits here:
*    create-cluster: Allow user to watch cluster installation logs
*    delete-cluster: Allow user to watch cluster uninstallation logs
*    create-cluster: Describe cluster automatically after creation
*    logs: Detach logs once operation is complete
