### PR TITLE
Fix/verify rate limits

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,12 +5,9 @@ go 1.13
 require (
 	github.com/AlecAivazis/survey/v2 v2.1.0
 	github.com/aws/aws-sdk-go v1.29.17
-	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
 	github.com/golang/mock v1.4.3
-	github.com/json-iterator/go v1.1.10 // indirect
-	github.com/konsorten/go-windows-terminal-sequences v1.0.3 // indirect
 	github.com/mattn/go-colorable v0.1.7 // indirect
 	github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d // indirect
 	github.com/mitchellh/go-homedir v1.1.0

--- a/pkg/aws/client.go
+++ b/pkg/aws/client.go
@@ -140,6 +140,7 @@ func (b *ClientBuilder) Build() (Client, error) {
 			MaxRetries: aws.Int(25),
 			// Set MinThrottleDelay to 1 second
 			Retryer: client.DefaultRetryer{
+				NumMaxRetries:    5,
 				MinThrottleDelay: 1 * time.Second,
 			},
 			Logger: logger,


### PR DESCRIPTION
Fixes: OSD-4671

I've realized a `Retryer: client.DefaultRetryer`  was defined but `NumMaxRetries` was missing. By default, the value is `0` which means there will be no retry unless we increase the number. 
Results are looking good, I've tested it in while loop on 5 different tabs, didn't see any `400` but responses may take longer as a result of retry mechanism.