### PR TITLE
Added Detailed Error Message for Throttling

### DIFF
--- a/cmd/verify/permissions/cmd.go
+++ b/cmd/verify/permissions/cmd.go
@@ -18,6 +18,7 @@ package permissions
 
 import (
 	"os"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -63,6 +64,10 @@ func run(cmd *cobra.Command, argv []string) {
 	ok, err := client.ValidateSCP()
 	if err != nil {
 		reporter.Errorf("Unable to validate SCP policies")
+		if strings.Contains(err.Error(), "Throttling: Rate exceeded") {
+			reporter.Errorf("Throttling: Rate exceeded. Please wait 3-5 minutes before retrying.")
+			os.Exit(1)
+		}
 		reporter.Errorf("%v", err)
 		os.Exit(1)
 	}


### PR DESCRIPTION
@vkareh  PTAL

This is how it displays now. 

E: Unable to validate SCP policies
E: Error simulating policy: Throttling: Rate exceeded
        status code: 400, request id: 315eb277-86ab-470a-bac5-92c586fa044d. Please wait 3-5 minutes before retrying.
