### PR TITLE
Ensure region on cluster create, update SDK

### DIFF
--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -97,6 +97,7 @@ func CreateCluster(client *cmv1.ClustersClient, config Spec) (*cmv1.Cluster, err
 
 	// Create the AWS client:
 	awsClient, err := aws.NewClient().
+		Region(config.Region).
 		Logger(logger).
 		Build()
 	if err != nil {

--- a/pkg/logging/ocm_logger.go
+++ b/pkg/logging/ocm_logger.go
@@ -93,11 +93,11 @@ func (l *OCMLogger) Debug(ctx context.Context, format string, args ...interface{
 }
 
 func (l *OCMLogger) Info(ctx context.Context, format string, args ...interface{}) {
-	l.logger.Infof(format, args...)
+	l.logger.Debugf(format, args...)
 }
 
 func (l *OCMLogger) Warn(ctx context.Context, format string, args ...interface{}) {
-	l.logger.Warnf(format, args...)
+	l.logger.Debugf(format, args...)
 }
 
 func (l *OCMLogger) Error(ctx context.Context, format string, args ...interface{}) {


### PR DESCRIPTION
When creating a cluster, we want to make sure we instantiate the AWS client using the same region that the cluster is set to.

This also updates the OCM SDK to the latest version, which adds extra logging output. After discussion with @cben, we've determined that most SDK logs belong to the debug level output.