### PR TITLE
verify-oc: Do not error out on invalid version

### DIFF
--- a/cmd/verify/oc/cmd.go
+++ b/cmd/verify/oc/cmd.go
@@ -18,7 +18,6 @@ package oc
 
 import (
 	"fmt"
-	"os"
 	"os/exec"
 	"regexp"
 	"strings"
@@ -49,7 +48,7 @@ func run(_ *cobra.Command, _ []string) {
 	if err != nil {
 		reporter.Errorf("OpenShift command-line tool is not installed.\n"+
 			"Go to %s to download the OpenShift client and add it to your PATH.", ocDownloadURL)
-		os.Exit(1)
+		return
 	}
 
 	// Parse the version for the OpenShift Client
@@ -57,14 +56,14 @@ func run(_ *cobra.Command, _ []string) {
 	isCorrectVersion, err := regexp.Match(`\W4.\d*`, output)
 	if err != nil {
 		reporter.Errorf("Failed to parse OpenShift Client version: %v", err)
-		os.Exit(1)
+		return
 	}
 
 	if !isCorrectVersion {
 		reporter.Warnf("Current OpenShift %s", version)
 		reporter.Warnf("Your version of the OpenShift command-line tool is not supported.")
 		fmt.Printf("Go to %s to download the latest version.\n", ocDownloadURL)
-		os.Exit(1)
+		return
 	}
 
 	reporter.Infof("Current OpenShift %s", version)


### PR DESCRIPTION
Detecting an invalid or unsupported version of the openshift-clients is
not an error, but the successful output of the 'verify' command. Since
we also call this command from the 'download' command, we need to ensure
that instead of exiting with an error, the command just ends and allows
the rest of 'download' to go through.