### PR TITLE
verify-oc: Ensure no output on error

### DIFF
--- a/cmd/verify/oc/cmd.go
+++ b/cmd/verify/oc/cmd.go
@@ -45,7 +45,7 @@ func run(_ *cobra.Command, _ []string) {
 	ocDownloadURL := "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest"
 
 	output, err := exec.Command("oc", "version").Output()
-	if err != nil {
+	if output == nil && err != nil {
 		reporter.Errorf("OpenShift command-line tool is not installed.\n"+
 			"Go to %s to download the OpenShift client and add it to your PATH.", ocDownloadURL)
 		return


### PR DESCRIPTION
When the oc client is not connected to any cluster, it still outputs the
version string, but also exits with an error. Instead of bailing out on
the error, we ensure that the version string is empty before we assume
that there is no 'oc' tool installed.