### PR TITLE
Use default region for CloudFormation stack

### DIFF
--- a/cmd/initialize/cmd.go
+++ b/cmd/initialize/cmd.go
@@ -78,17 +78,10 @@ func run(cmd *cobra.Command, argv []string) {
 	reporter := rprtr.CreateReporterOrExit()
 	logger := logging.CreateLoggerOrExit(reporter)
 
-	// Get AWS region
-	region, err := aws.GetRegion(args.region)
-	if err != nil {
-		reporter.Errorf("Error getting region: %v", err)
-		os.Exit(1)
-	}
-
 	// Create the AWS client:
 	client, err := aws.NewClient().
 		Logger(logger).
-		Region(region).
+		Region(aws.DefaultRegion).
 		Build()
 	if err != nil {
 		reporter.Errorf("Error creating AWS client: %v", err)

--- a/pkg/aws/client.go
+++ b/pkg/aws/client.go
@@ -48,6 +48,10 @@ import (
 const (
 	AdminUserName        = "osdCcsAdmin"
 	OsdCcsAdminStackName = "osdCcsAdminIAMUser"
+
+	// Since CloudFormation stacks are region-dependent, we hard-code OCM's default region and
+	// then use it to ensure that the user always gets the stack from the same region.
+	DefaultRegion = "us-east-1"
 )
 
 // Client defines a client interface

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -97,8 +97,8 @@ func CreateCluster(client *cmv1.ClustersClient, config Spec) (*cmv1.Cluster, err
 
 	// Create the AWS client:
 	awsClient, err := aws.NewClient().
-		Region(config.Region).
 		Logger(logger).
+		Region(aws.DefaultRegion).
 		Build()
 	if err != nil {
 		return nil, fmt.Errorf("Failed to create AWS client: %v", err)

--- a/pkg/ocm/regions/regions.go
+++ b/pkg/ocm/regions/regions.go
@@ -33,7 +33,10 @@ func GetRegions(client *cmv1.Client) (regions []*cmv1.CloudRegion, err error) {
 	}
 
 	// Create the AWS client:
-	awsClient, err := aws.NewClient().Logger(logger).Build()
+	awsClient, err := aws.NewClient().
+		Logger(logger).
+		Region(aws.DefaultRegion).
+		Build()
 	if err != nil {
 		return nil, fmt.Errorf("Failed to create AWS client: %v", err)
 	}


### PR DESCRIPTION
Since a CloudFormation stack is region-specific, we avoid using the
user-set flag and hard-code a default AWS region. This ensures that the
stack is queried always from the same region, regardless where the
cluster is being created.