### PR TITLE
refactor(create): add credential check for osdCcsAdmin when cluster starts to be created

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .idea/
+.vscode/
 docs/*.1
 docs/*.rst
 /moactl

--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -252,6 +252,25 @@ func run(cmd *cobra.Command, _ []string) {
 		reporter.Errorf("Error getting region: %v", err)
 		os.Exit(1)
 	}
+
+	// Create the AWS client:
+	client, err := aws.NewClient().
+		Logger(logger).
+		Region(aws.DefaultRegion).
+		Build()
+	if err != nil {
+		reporter.Errorf("Error creating AWS client: %v", err)
+		os.Exit(1)
+	}
+
+	// Validate AWS credentials for current user
+	reporter.Infof("Validating AWS credentials for CFUser...")
+	if err = client.ValidateCFUserCredentials(); err != nil {
+		reporter.Errorf("Error validating AWS credentials: %v", err)
+		os.Exit(1)
+	}
+	reporter.Infof("AWS credentials are valid!")
+
 	regionList, regionAZ, err := getRegionList(ocmClient, multiAZ)
 	if err != nil {
 		reporter.Errorf(fmt.Sprintf("%s", err))


### PR DESCRIPTION
Fixes: OSD-4707

The credential check has been added to cluster create command.
Example output when the creds for `osdCcsAdmin` are being changed manually

```shell
 └─ ▶./moactl create cluster -c boran-test
I: Validating AWS credentials for CFUser...
E: Error validating AWS credentials: Invalid CloudFormation stack credentials: osdCcsAdmin is not valid
you can recreate the CloudFormation stack with:
moactl init --delete-stack && moactl init

```