### PR TITLE
list-versions: Add command to list enabled versions

### DIFF
--- a/cmd/list/cmd.go
+++ b/cmd/list/cmd.go
@@ -25,6 +25,7 @@ import (
 	"github.com/openshift/moactl/cmd/list/ingress"
 	"github.com/openshift/moactl/cmd/list/region"
 	"github.com/openshift/moactl/cmd/list/user"
+	"github.com/openshift/moactl/cmd/list/version"
 )
 
 var Cmd = &cobra.Command{
@@ -40,4 +41,5 @@ func init() {
 	Cmd.AddCommand(ingress.Cmd)
 	Cmd.AddCommand(region.Cmd)
 	Cmd.AddCommand(user.Cmd)
+	Cmd.AddCommand(version.Cmd)
 }

--- a/cmd/list/version/cmd.go
+++ b/cmd/list/version/cmd.go
@@ -1,0 +1,112 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package version
+
+import (
+	"fmt"
+	"os"
+	"text/tabwriter"
+
+	"github.com/spf13/cobra"
+
+	"github.com/openshift/moactl/pkg/logging"
+	"github.com/openshift/moactl/pkg/ocm"
+	"github.com/openshift/moactl/pkg/ocm/versions"
+	rprtr "github.com/openshift/moactl/pkg/reporter"
+)
+
+var args struct {
+	channel string
+}
+
+var Cmd = &cobra.Command{
+	Use:     "versions",
+	Aliases: []string{"version"},
+	Short:   "List available versions",
+	Long:    "List versions of OpenShift that are available for creating clusters.",
+	Example: `  # List all OpenShift versions
+  moactl list versions`,
+	Run: run,
+}
+
+func init() {
+	flags := Cmd.Flags()
+	flags.StringVar(
+		&args.channel,
+		"channel",
+		"",
+		"List only versions from the specified channel group",
+	)
+	flags.MarkHidden("channel")
+}
+
+func run(cmd *cobra.Command, _ []string) {
+	reporter := rprtr.CreateReporterOrExit()
+	logger := logging.CreateLoggerOrExit(reporter)
+
+	// Create the client for the OCM API:
+	ocmConnection, err := ocm.NewConnection().
+		Logger(logger).
+		Build()
+	if err != nil {
+		reporter.Errorf("Failed to create OCM connection: %v", err)
+		os.Exit(1)
+	}
+	defer func() {
+		err = ocmConnection.Close()
+		if err != nil {
+			reporter.Errorf("Failed to close OCM connection: %v", err)
+		}
+	}()
+
+	// Get the client for the OCM collection of clusters:
+	ocmClient := ocmConnection.ClustersMgmt().V1()
+
+	// Try to find the cluster:
+	reporter.Debugf("Fetching versions")
+	versions, err := versions.GetVersions(ocmClient)
+	if err != nil {
+		reporter.Errorf("Failed to fetch versions: %v", err)
+		os.Exit(1)
+	}
+
+	if len(versions) == 0 {
+		reporter.Warnf("There are no OpenShift versions available")
+		os.Exit(1)
+	}
+
+	// Create the writer that will be used to print the tabulated results:
+	writer := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintf(writer, "ID\t\tDEFAULT\n")
+
+	for _, version := range versions {
+		if !version.Enabled() {
+			continue
+		}
+		if cmd.Flags().Changed("channel") {
+			if args.channel != version.ChannelGroup() {
+				continue
+			}
+		}
+		fmt.Fprintf(writer,
+			"%s\t\t%t\n",
+			version.ID(),
+			version.Default(),
+		)
+	}
+	writer.Flush()
+}

--- a/docs/moactl_list.md
+++ b/docs/moactl_list.md
@@ -27,4 +27,5 @@ List all resources of a specific type
 * [moactl list ingresses](moactl_list_ingresses.md)	 - List cluster Ingresses
 * [moactl list regions](moactl_list_regions.md)	 - List available regions
 * [moactl list users](moactl_list_users.md)	 - List cluster users
+* [moactl list versions](moactl_list_versions.md)	 - List available versions
 

--- a/docs/moactl_list_versions.md
+++ b/docs/moactl_list_versions.md
@@ -1,0 +1,36 @@
+## moactl list versions
+
+List available versions
+
+### Synopsis
+
+List versions of OpenShift that are available for creating clusters.
+
+```
+moactl list versions [flags]
+```
+
+### Examples
+
+```
+  # List all OpenShift versions
+  moactl list versions
+```
+
+### Options
+
+```
+  -h, --help   help for versions
+```
+
+### Options inherited from parent commands
+
+```
+      --debug     Enable debug mode.
+  -v, --v Level   log level for V logs
+```
+
+### SEE ALSO
+
+* [moactl list](moactl_list.md)	 - List all resources of a specific type
+


### PR DESCRIPTION
When creating a cluster, the user is able to pass a parameter with the
version of OpenShift to use. Unless the user goes through the
interactive flow, they won't be able to see which versions are
available. This command allows a user to view a list of all enabled
versions in the current environment.

https://asciinema.org/a/3G1EgphgPxmcD5hK2M1XVTuuE