### PR TITLE
verify-permissions: Do not check ViewBilling policy

### DIFF
--- a/assets/bindata.go
+++ b/assets/bindata.go
@@ -278,7 +278,6 @@ var _templatesPoliciesOsd_scp_policyJson = []byte(`{
             "Effect": "Allow",
             "Action": [
                 "aws-portal:ViewAccount",
-                "aws-portal:ViewBilling",
                 "aws-portal:ViewUsage"
             ],
             "Resource": [
@@ -286,7 +285,8 @@ var _templatesPoliciesOsd_scp_policyJson = []byte(`{
             ]
         }
     ]
-}`)
+}
+`)
 
 func templatesPoliciesOsd_scp_policyJsonBytes() ([]byte, error) {
 	return _templatesPoliciesOsd_scp_policyJson, nil

--- a/templates/policies/osd_scp_policy.json
+++ b/templates/policies/osd_scp_policy.json
@@ -167,7 +167,6 @@
             "Effect": "Allow",
             "Action": [
                 "aws-portal:ViewAccount",
-                "aws-portal:ViewBilling",
                 "aws-portal:ViewUsage"
             ],
             "Resource": [


### PR DESCRIPTION
Since billing is recommended, but not required, we should not check
during the verify-permission check so as to not block the user if they
do not have this policy.