### PR TITLE
tests: Fix expected text comparison

### DIFF
--- a/pkg/aws/client.go
+++ b/pkg/aws/client.go
@@ -287,7 +287,7 @@ func (c *awsClient) checkStackReadyOrNotExisting(stackName string) (stackReady b
 				return true, nil
 			}
 			if *summary.StackStatus != cloudformation.StackStatusDeleteComplete {
-				return false, fmt.Errorf("Error creating user: Cloudformation stack %s existing with status %s."+
+				return false, fmt.Errorf("Error creating user: Cloudformation stack %s exists with status %s. "+
 					"Expected status is %s.\n"+
 					"Ensure user osdCcsAdmin does not exist, then retry with\n"+
 					"moactl init --delete-stack; moactl init",

--- a/pkg/aws/client_test.go
+++ b/pkg/aws/client_test.go
@@ -94,7 +94,8 @@ var _ = Describe("Client", func() {
 
 					Expect(stackCreated).To(BeFalse())
 					Expect(err).To(HaveOccurred())
-					Expect(err.Error()).To(ContainSubstring("existing with status ROLLBACK_COMPLETE. Expected status CREATE_COMPLETE"))
+					Expect(err.Error()).To(ContainSubstring(
+						"exists with status ROLLBACK_COMPLETE. Expected status is CREATE_COMPLETE"))
 				})
 			})
 		})


### PR DESCRIPTION
When running `make test` there is text comparison that doesn't match:
```
• Failure [0.000 seconds]
Client
/home/vkareh/go/src/github.com/openshift/moactl/pkg/aws/client_test.go:15
  EnsureOsdCcsAdminUser
  /home/vkareh/go/src/github.com/openshift/moactl/pkg/aws/client_test.go:41
    When the cloudformation stack already exists
    /home/vkareh/go/src/github.com/openshift/moactl/pkg/aws/client_test.go:49
      When stack is in ROLLBACK_COMPLETE state
      /home/vkareh/go/src/github.com/openshift/moactl/pkg/aws/client_test.go:87
        Returns error telling the stack is in an invalid state [It]
        /home/vkareh/go/src/github.com/openshift/moactl/pkg/aws/client_test.go:92

        Expected
            <string>: Error creating user: Cloudformation stack fake-stack existing with status ROLLBACK_COMPLETE.Expected status is CREATE_COMPLETE.
            Ensure user osdCcsAdmin does not exist, then retry with
            moactl init --delete-stack; moactl init
        to contain substring
            <string>: existing with status ROLLBACK_COMPLETE.Expected status CREATE_COMPLETE

        /home/vkareh/go/src/github.com/openshift/moactl/pkg/aws/client_test.go:97
```