### PR TITLE
login: Ensure token is required

### DIFF
--- a/cmd/login/cmd.go
+++ b/cmd/login/cmd.go
@@ -162,6 +162,7 @@ func run(cmd *cobra.Command, argv []string) {
 		fmt.Println("To login to your Red Hat account, get an offline access token at", uiTokenPage)
 		token, err = interactive.GetPassword(interactive.Input{
 			Question: "Copy the token and paste it here",
+			Required: true,
 		})
 		if err != nil {
 			reporter.Errorf("Failed to parse token: %v", err)


### PR DESCRIPTION
When asking the user for the OCM access token, the field should be
required and not allow the user through if they do not supply it.