### PR TITLE
create-cluster: Allow selective override of the marketplace AMI

### DIFF
--- a/docs/moactl_create_cluster.md
+++ b/docs/moactl_create_cluster.md
@@ -35,6 +35,7 @@ moactl create cluster [flags]
       --host-prefix int               Subnet prefix length to assign to each individual node. For example, if host prefix is set to "23", then each node is assigned a /23 subnet out of the given CIDR.
       --private                       Restrict master API endpoint and application routes to direct, private connectivity.
       --watch                         Watch cluster installation logs.
+      --use-paid-ami                  Whether to use the paid AMI from AWS. Requires a valid subscription to the MOA Product.
   -h, --help                          help for cluster
 ```
 

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/onsi/ginkgo v1.11.0
 	github.com/onsi/gomega v1.7.0
-	github.com/openshift-online/ocm-sdk-go v0.1.123
+	github.com/openshift-online/ocm-sdk-go v0.1.126
 	github.com/prometheus/common v0.11.1 // indirect
 	github.com/sirupsen/logrus v1.6.0
 	github.com/spf13/cobra v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -282,8 +282,8 @@ github.com/onsi/gomega v1.4.3/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1Cpa
 github.com/onsi/gomega v1.7.0 h1:XPnZz8VVBHjVsy1vzJmRwIcSwiUO+JFfrv/xGiigmME=
 github.com/onsi/gomega v1.7.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/op/go-logging v0.0.0-20160315200505-970db520ece7/go.mod h1:HzydrMdWErDVzsI23lYNej1Htcns9BCg93Dk0bBINWk=
-github.com/openshift-online/ocm-sdk-go v0.1.123 h1:2jB6fCf1ikeKWoxcQA7+f8VFzA58tRhew2HHR5pbY9Y=
-github.com/openshift-online/ocm-sdk-go v0.1.123/go.mod h1:3i3a/LEYtC7DMor3N94PTPn1+0qq+Fk+iLjt1Z0WVCs=
+github.com/openshift-online/ocm-sdk-go v0.1.126 h1:R7LtZ0PNr+1OPn6j7oz0tyzzm5cRQHFOqOPDfFn3vVU=
+github.com/openshift-online/ocm-sdk-go v0.1.126/go.mod h1:3i3a/LEYtC7DMor3N94PTPn1+0qq+Fk+iLjt1Z0WVCs=
 github.com/opentracing-contrib/go-observer v0.0.0-20170622124052-a52f23424492/go.mod h1:Ngi6UdF0k5OKD5t5wlmGhe/EDKPoUM3BXZSSfIuJbis=
 github.com/opentracing/basictracer-go v1.0.0/go.mod h1:QfBfYuafItcjQuMwinw9GhYKwFXS9KnPs5lxoYwgW74=
 github.com/opentracing/opentracing-go v1.0.2/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=

--- a/pkg/ocm/properties/properties.go
+++ b/pkg/ocm/properties/properties.go
@@ -27,3 +27,6 @@ const prefix = "moa_"
 const CreatorARN = prefix + "creator_arn"
 
 const CLIVersion = prefix + "cli_version"
+
+// UseMarketplaceAMI tells the cluster provisioner whether to use the AMRO AMI ID from the AWS marketplace.
+const UseMarketplaceAMI = prefix + "use_marketplace_ami"

--- a/pkg/ocm/versions/versions.go
+++ b/pkg/ocm/versions/versions.go
@@ -26,7 +26,7 @@ func GetVersions(client *cmv1.Client, channelGroup string) (versions []*cmv1.Ver
 	collection := client.Versions()
 	page := 1
 	size := 100
-	filter := "enabled = 'true'"
+	filter := "enabled = 'true' AND moa_enabled = 'true'"
 	if channelGroup != "" {
 		filter = fmt.Sprintf("%s AND channel_group = '%s'", filter, channelGroup)
 	}


### PR DESCRIPTION
Since the MOA AMIs are not yet live in the AWS Marketplace, only
allowlisted accounts with a valid subscription will be able to use them.
Using the new --use-marketplace-ami flag will tell OCM that it should
use the MOA image, rather than the default OSD one.
