### PR TITLE
versions: Allow querying for channel-groups

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -518,7 +518,7 @@ func validateVersion(version string, versionList []string) (string, error) {
 }
 
 func getVersionList(client *cmv1.Client) (versionList []string, err error) {
-	versions, err := versions.GetVersions(client)
+	versions, err := versions.GetVersions(client, "stable")
 	if err != nil {
 		err = fmt.Errorf("Failed to retrieve versions: %s", err)
 		return

--- a/cmd/list/version/cmd.go
+++ b/cmd/list/version/cmd.go
@@ -30,7 +30,7 @@ import (
 )
 
 var args struct {
-	channel string
+	channelGroup string
 }
 
 var Cmd = &cobra.Command{
@@ -46,12 +46,12 @@ var Cmd = &cobra.Command{
 func init() {
 	flags := Cmd.Flags()
 	flags.StringVar(
-		&args.channel,
-		"channel",
-		"",
+		&args.channelGroup,
+		"channel-group",
+		"stable",
 		"List only versions from the specified channel group",
 	)
-	flags.MarkHidden("channel")
+	flags.MarkHidden("channel-group")
 }
 
 func run(cmd *cobra.Command, _ []string) {
@@ -78,7 +78,7 @@ func run(cmd *cobra.Command, _ []string) {
 
 	// Try to find the cluster:
 	reporter.Debugf("Fetching versions")
-	versions, err := versions.GetVersions(ocmClient)
+	versions, err := versions.GetVersions(ocmClient, args.channelGroup)
 	if err != nil {
 		reporter.Errorf("Failed to fetch versions: %v", err)
 		os.Exit(1)
@@ -96,11 +96,6 @@ func run(cmd *cobra.Command, _ []string) {
 	for _, version := range versions {
 		if !version.Enabled() {
 			continue
-		}
-		if cmd.Flags().Changed("channel") {
-			if args.channel != version.ChannelGroup() {
-				continue
-			}
 		}
 		fmt.Fprintf(writer,
 			"%s\t\t%t\n",

--- a/pkg/ocm/versions/versions.go
+++ b/pkg/ocm/versions/versions.go
@@ -17,17 +17,23 @@ limitations under the License.
 package versions
 
 import (
+	"fmt"
+
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 )
 
-func GetVersions(client *cmv1.Client) (versions []*cmv1.Version, err error) {
+func GetVersions(client *cmv1.Client, channelGroup string) (versions []*cmv1.Version, err error) {
 	collection := client.Versions()
 	page := 1
 	size := 100
+	filter := "enabled = 'true'"
+	if channelGroup != "" {
+		filter = fmt.Sprintf("%s AND channel_group = '%s'", filter, channelGroup)
+	}
 	for {
 		var response *cmv1.VersionsListResponse
 		response, err = collection.List().
-			Search("enabled = 'true'").
+			Search(filter).
 			Order("default desc, id asc").
 			Page(page).
 			Size(size).


### PR DESCRIPTION
We keep the flag hidden for now, and we hard-code the default to
'stable' when creating clusters. Eventually we will want to expose this
to end-users and tell the OCM what channel group to use.