### PR TITLE
Added Timestamp to created date

### DIFF
--- a/cmd/describe/cluster/cmd.go
+++ b/cmd/describe/cluster/cmd.go
@@ -157,7 +157,7 @@ func run(_ *cobra.Command, argv []string) {
 		cluster.Region().ID(),
 		cluster.State(),
 		cluster.Version().ChannelGroup(),
-		cluster.CreationTimestamp().Format("Jan _2, 2006"),
+		cluster.CreationTimestamp().Format("Jan _2 2006 15:04:05 MST"),
 	)
 	fmt.Println()
 }


### PR DESCRIPTION
@vkareh PTAL

In the logs we have the format as 2020-09-10T20:01:09Z with z for UTC and T for timestamp.  

Format "Sep 10 2020 19:12:55 UTC" was more user friendly. 

PTAL