### PR TITLE
verify-quota: Avoid nil pointer dereferencing

### DIFF
--- a/pkg/aws/client.go
+++ b/pkg/aws/client.go
@@ -438,7 +438,7 @@ func (c *awsClient) ValidateQuota() (bool, error) {
 		}
 
 		serviceQuota, err := GetServiceQuota(serviceQuotas, quota.QuotaCode)
-		if err != nil {
+		if err != nil || serviceQuota == nil || (*serviceQuota).Value == nil {
 			return false, fmt.Errorf("Error getting AWS service quota: %s %v", quota.ServiceCode, err)
 		}
 

--- a/pkg/aws/quota.go
+++ b/pkg/aws/quota.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"fmt"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/servicequotas"
 )
 
@@ -20,73 +21,68 @@ var serviceQuotaServices = []quota{
 		ServiceCode:  "ec2",
 		QuotaCode:    "L-0263D0A3",
 		QuotaName:    "Number of EIPs - VPC EIPs",
-		DesiredValue: Float64(5.0),
+		DesiredValue: aws.Float64(5.0),
 	},
 	{
 		ServiceCode:  "ec2",
 		QuotaCode:    "L-1216C47A",
 		QuotaName:    "Running On-Demand Standard (A, C, D, H, I, M, R, T, Z) instances",
-		DesiredValue: Float64(200.0),
+		DesiredValue: aws.Float64(200.0),
 	},
 	{
 		ServiceCode:  "vpc",
 		QuotaCode:    "L-F678F1CE",
 		QuotaName:    "VPCs per Region",
-		DesiredValue: Float64(5.0),
+		DesiredValue: aws.Float64(5.0),
 	},
 	{
 		ServiceCode:  "vpc",
 		QuotaCode:    "L-A4707A72",
 		QuotaName:    "Internet gateways per Region",
-		DesiredValue: Float64(5.0),
+		DesiredValue: aws.Float64(5.0),
 	},
 	{
 		ServiceCode:  "vpc",
 		QuotaCode:    "L-DF5E4CA3",
 		QuotaName:    "Network interfaces per Region",
-		DesiredValue: Float64(5000.0),
+		DesiredValue: aws.Float64(5000.0),
 	},
 	{
 		ServiceCode:  "ebs",
 		QuotaCode:    "L-D18FCD1D",
 		QuotaName:    "General Purpose SSD (gp2) volume storage",
-		DesiredValue: Float64(300.0),
+		DesiredValue: aws.Float64(300.0),
 	},
 	{
 		ServiceCode:  "ebs",
 		QuotaCode:    "L-309BACF6",
 		QuotaName:    "Number of EBS snapshots",
-		DesiredValue: Float64(300.0),
+		DesiredValue: aws.Float64(300.0),
 	},
 	{
 		ServiceCode:  "ebs",
 		QuotaCode:    "L-B3A130E6",
 		QuotaName:    "Provisioned IOPS",
-		DesiredValue: Float64(300000.0),
+		DesiredValue: aws.Float64(300000.0),
 	},
 	{
 		ServiceCode:  "ebs",
 		QuotaCode:    "L-FD252861",
 		QuotaName:    "Provisioned IOPS SSD (io1) volume storage",
-		DesiredValue: Float64(300.0),
+		DesiredValue: aws.Float64(300.0),
 	},
 	{
 		ServiceCode:  "elasticloadbalancing",
 		QuotaCode:    "L-53DA6B97",
 		QuotaName:    "Application Load Balancers per Region",
-		DesiredValue: Float64(50.0),
+		DesiredValue: aws.Float64(50.0),
 	},
 	{
 		ServiceCode:  "elasticloadbalancing",
 		QuotaCode:    "L-E9E9831D",
 		QuotaName:    "Classic Load Balancers per Region",
-		DesiredValue: Float64(20.0),
+		DesiredValue: aws.Float64(20.0),
 	},
-}
-
-// Float64 returns a pointer to the float64 value passed in
-func Float64(v float64) *float64 {
-	return &v
 }
 
 // ListServiceQuotas list available quotas for service


### PR DESCRIPTION
When fetching quota for comparison, if the AWS response contains a nil
servicequota item, it crashes moactl.