### PR TITLE
versions: Expose channel-group

### DIFF
--- a/cmd/list/version/cmd.go
+++ b/cmd/list/version/cmd.go
@@ -48,10 +48,9 @@ func init() {
 	flags.StringVar(
 		&args.channelGroup,
 		"channel-group",
-		"stable",
+		versions.DefaultChannelGroup,
 		"List only versions from the specified channel group",
 	)
-	flags.MarkHidden("channel-group")
 }
 
 func run(cmd *cobra.Command, _ []string) {

--- a/docs/moactl_create_cluster.md
+++ b/docs/moactl_create_cluster.md
@@ -27,6 +27,7 @@ moactl create cluster [flags]
       --multi-az                      Deploy to multiple data centers.
   -r, --region string                 AWS region where your worker pool will be located. (overrides the AWS_REGION environment variable)
       --version string                Version of OpenShift that will be used to install the cluster, for example "4.3.10"
+      --channel-group string          Channel group is the name of the group where this image belongs, for example "stable" or "fast". (default "stable")
       --compute-machine-type string   Instance type for the compute nodes. Determines the amount of memory and vCPU allocated to each compute node.
       --compute-nodes int             Number of worker nodes to provision per zone. Single zone clusters need at least 4 nodes, multizone clusters need at least 9 nodes. (default 4)
       --machine-cidr ipNet            Block of IP addresses used by OpenShift while installing the cluster, for example "10.0.0.0/16".

--- a/docs/moactl_list_versions.md
+++ b/docs/moactl_list_versions.md
@@ -20,7 +20,8 @@ moactl list versions [flags]
 ### Options
 
 ```
-  -h, --help   help for versions
+      --channel-group string   List only versions from the specified channel group (default "stable")
+  -h, --help                   help for versions
 ```
 
 ### Options inherited from parent commands

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/onsi/ginkgo v1.11.0
 	github.com/onsi/gomega v1.7.0
-	github.com/openshift-online/ocm-sdk-go v0.1.126
+	github.com/openshift-online/ocm-sdk-go v0.1.128
 	github.com/prometheus/common v0.11.1 // indirect
 	github.com/sirupsen/logrus v1.6.0
 	github.com/spf13/cobra v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -282,8 +282,8 @@ github.com/onsi/gomega v1.4.3/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1Cpa
 github.com/onsi/gomega v1.7.0 h1:XPnZz8VVBHjVsy1vzJmRwIcSwiUO+JFfrv/xGiigmME=
 github.com/onsi/gomega v1.7.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/op/go-logging v0.0.0-20160315200505-970db520ece7/go.mod h1:HzydrMdWErDVzsI23lYNej1Htcns9BCg93Dk0bBINWk=
-github.com/openshift-online/ocm-sdk-go v0.1.126 h1:R7LtZ0PNr+1OPn6j7oz0tyzzm5cRQHFOqOPDfFn3vVU=
-github.com/openshift-online/ocm-sdk-go v0.1.126/go.mod h1:3i3a/LEYtC7DMor3N94PTPn1+0qq+Fk+iLjt1Z0WVCs=
+github.com/openshift-online/ocm-sdk-go v0.1.128 h1:AlX7PkZOuZJPBzMM2CgF22YGMp6M9+UUPp8bfGORTDM=
+github.com/openshift-online/ocm-sdk-go v0.1.128/go.mod h1:3i3a/LEYtC7DMor3N94PTPn1+0qq+Fk+iLjt1Z0WVCs=
 github.com/opentracing-contrib/go-observer v0.0.0-20170622124052-a52f23424492/go.mod h1:Ngi6UdF0k5OKD5t5wlmGhe/EDKPoUM3BXZSSfIuJbis=
 github.com/opentracing/basictracer-go v1.0.0/go.mod h1:QfBfYuafItcjQuMwinw9GhYKwFXS9KnPs5lxoYwgW74=
 github.com/opentracing/opentracing-go v1.0.2/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -39,11 +39,12 @@ var clusterKeyRE = regexp.MustCompile(`^(\w|-)+$`)
 // Spec is the configuration for a cluster spec.
 type Spec struct {
 	// Basic configs
-	Name       string
-	Region     string
-	MultiAZ    bool
-	Version    string
-	Expiration time.Time
+	Name         string
+	Region       string
+	MultiAZ      bool
+	Version      string
+	ChannelGroup string
+	Expiration   time.Time
 
 	// Scaling config
 	ComputeMachineType string
@@ -327,10 +328,13 @@ func createClusterSpec(config Spec, awsClient aws.Client) (*cmv1.Cluster, error)
 	if config.Version != "" {
 		clusterBuilder = clusterBuilder.Version(
 			cmv1.NewVersion().
-				ID(config.Version),
+				ID(config.Version).
+				ChannelGroup(config.ChannelGroup),
 		)
 
-		reporter.Debugf("Using OpenShift version '%s'", config.Version)
+		reporter.Debugf(
+			"Using OpenShift version '%s' on channel group '%s'",
+			config.Version, config.ChannelGroup)
 	}
 
 	if !config.Expiration.IsZero() {

--- a/pkg/ocm/versions/versions.go
+++ b/pkg/ocm/versions/versions.go
@@ -22,6 +22,8 @@ import (
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 )
 
+const DefaultChannelGroup = "stable"
+
 func GetVersions(client *cmv1.Client, channelGroup string) (versions []*cmv1.Version, err error) {
 	collection := client.Versions()
 	page := 1


### PR DESCRIPTION
When listing versions or creating a cluster, we can now specify the
channel group to use, with a default of 'stable'. Interactive mode now
reads the channel group flag and displays the correct list when creating
the cluster.

https://asciinema.org/a/b4vW7EtlDp0vRBbljSbnnGwBa