### PR TITLE
verify-quota: Check for only 100 vCPU

### DIFF
--- a/pkg/aws/quota.go
+++ b/pkg/aws/quota.go
@@ -27,7 +27,7 @@ var serviceQuotaServices = []quota{
 		ServiceCode:  "ec2",
 		QuotaCode:    "L-1216C47A",
 		QuotaName:    "Running On-Demand Standard (A, C, D, H, I, M, R, T, Z) instances",
-		DesiredValue: aws.Float64(200.0),
+		DesiredValue: aws.Float64(100.0),
 	},
 	{
 		ServiceCode:  "vpc",


### PR DESCRIPTION
To allow users to create a single cluster, we can decrease the quota
check for only 100 vCPU.