### PR TITLE
 Rotate osdCcsAdmin credentails on creation of each cluster

### DIFF
--- a/assets/bindata.go
+++ b/assets/bindata.go
@@ -64,31 +64,6 @@ var _templatesCloudformationIam_user_osdccsadminJson = []byte(`{
         ],
         "UserName": "osdCcsAdmin"
       }
-    },
-    "osdCcsAdminAccessKeys": {
-      "Type": "AWS::IAM::AccessKey",
-      "Properties": {
-        "UserName": {
-          "Ref": "osdCcsAdmin"
-        }
-      }
-    }
-  },
-  "Outputs": {
-    "AccessKey": {
-      "Value": {
-        "Ref": "osdCcsAdminAccessKeys"
-      },
-      "Description": "Access Key ID for osdCcsAdmin IAM User"
-    },
-    "SecretKey": {
-      "Value": {
-        "Fn::GetAtt": [
-          "osdCcsAdminAccessKeys",
-          "SecretAccessKey"
-        ]
-      },
-      "Description": "Secret Access Key for osdCcsAdmin IAM User"
     }
   }
 }

--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -294,23 +294,6 @@ func run(cmd *cobra.Command, _ []string) {
 		reporter.Errorf("Error getting region: %v", err)
 		os.Exit(1)
 	}
-	// Create the AWS client:
-	client, err := aws.NewClient().
-		Logger(logger).
-		Region(aws.DefaultRegion).
-		Build()
-	if err != nil {
-		reporter.Errorf("Error creating AWS client: %v", err)
-		os.Exit(1)
-	}
-
-	// Validate AWS credentials for current user
-	reporter.Debugf("Validating AWS credentials...")
-	if err = client.ValidateCFUserCredentials(); err != nil {
-		reporter.Errorf("Error validating AWS credentials for user '%s': %v", aws.AdminUserName, err)
-		os.Exit(1)
-	}
-	reporter.Debugf("AWS credentials are valid!")
 
 	regionList, regionAZ, err := regions.GetRegionList(ocmClient, multiAZ)
 	if err != nil {
@@ -330,6 +313,7 @@ func run(cmd *cobra.Command, _ []string) {
 			os.Exit(1)
 		}
 	}
+
 	if region == "" {
 		reporter.Errorf("Expected a valid AWS region")
 		os.Exit(1)
@@ -517,6 +501,9 @@ func run(cmd *cobra.Command, _ []string) {
 		}
 	}
 
+	reporter.Infof("Creating cluster '%s'", clusterName)
+	reporter.Infof("To view a list of clusters and their status, run 'rosa list clusters'")
+
 	cluster, err := clusterprovider.CreateCluster(ocmClient.Clusters(), clusterConfig)
 	if err != nil {
 		if args.dryRun {
@@ -533,9 +520,6 @@ func run(cmd *cobra.Command, _ []string) {
 			clusterName)
 		os.Exit(0)
 	}
-
-	reporter.Infof("Creating cluster with identifier '%s' and name '%s'", cluster.ID(), clusterName)
-	reporter.Infof("To view a list of clusters and their status, run 'rosa list clusters'")
 
 	reporter.Infof("Cluster '%s' has been created.", clusterName)
 	reporter.Infof(

--- a/cmd/validations/validations.go
+++ b/cmd/validations/validations.go
@@ -24,7 +24,7 @@ func Validations(cmd *cobra.Command, _ []string) {
 	}
 
 	reporter.Debugf("Validating cloudformation stack exists")
-	stackExist, err := client.CheckStackReadyOrNotExisting(aws.OsdCcsAdminStackName)
+	stackExist, _, err := client.CheckStackReadyOrNotExisting(aws.OsdCcsAdminStackName)
 	if !stackExist || err != nil {
 		reporter.Errorf("Cloudformation stack does not exist. Run `rosa init` first")
 		os.Exit(1)

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -295,7 +295,7 @@ func createClusterSpec(config Spec, awsClient aws.Client) (*cmv1.Cluster, error)
 	}
 
 	// Create the access key for the AWS user:
-	awsAccessKey, err := awsClient.GetAccessKeyFromStack(aws.OsdCcsAdminStackName)
+	awsAccessKey, err := awsClient.GetAWSAccessKeys()
 	if err != nil {
 		return nil, fmt.Errorf("Failed to get access keys for user '%s': %v", aws.AdminUserName, err)
 	}

--- a/templates/cloudformation/iam_user_osdCcsAdmin.json
+++ b/templates/cloudformation/iam_user_osdCcsAdmin.json
@@ -8,31 +8,6 @@
         ],
         "UserName": "osdCcsAdmin"
       }
-    },
-    "osdCcsAdminAccessKeys": {
-      "Type": "AWS::IAM::AccessKey",
-      "Properties": {
-        "UserName": {
-          "Ref": "osdCcsAdmin"
-        }
-      }
-    }
-  },
-  "Outputs": {
-    "AccessKey": {
-      "Value": {
-        "Ref": "osdCcsAdminAccessKeys"
-      },
-      "Description": "Access Key ID for osdCcsAdmin IAM User"
-    },
-    "SecretKey": {
-      "Value": {
-        "Fn::GetAtt": [
-          "osdCcsAdminAccessKeys",
-          "SecretAccessKey"
-        ]
-      },
-      "Description": "Secret Access Key for osdCcsAdmin IAM User"
     }
   }
 }


### PR DESCRIPTION
Rotate IAM access keys for the IAM user osdCcsAdmin user each time we use the client to create a cluster. There is no need to permanently store these credentials since they are only used on create, the cluster uses a completely different set of IAM credentials provisioned by this user.