### PR TITLE
idp: Add support for GitLab

### DIFF
--- a/cmd/create/idp/cmd.go
+++ b/cmd/create/idp/cmd.go
@@ -48,6 +48,9 @@ var args struct {
 	githubOrganizations string
 	githubTeams         string
 
+	// GitLab
+	gitlabURL string
+
 	// Google
 	googleHostedDomain string
 
@@ -68,7 +71,7 @@ var args struct {
 }
 
 // TODO: Add gitlab
-var validIdps []string = []string{"github", "google", "ldap", "openid"}
+var validIdps []string = []string{"github", "gitlab", "google", "ldap", "openid"}
 
 var Cmd = &cobra.Command{
 	Use:   "idp",
@@ -153,6 +156,14 @@ func init() {
 		"",
 		"GitHub: Only users that are members of at least one of the listed teams will be allowed to log in. "+
 			"The format is <org>/<team>.\n",
+	)
+
+	// GitLab
+	flags.StringVar(
+		&args.gitlabURL,
+		"host-url",
+		"https://gitlab.com",
+		"GitLab: The host URL of a GitLab provider.",
 	)
 
 	// Google
@@ -367,6 +378,8 @@ func run(cmd *cobra.Command, _ []string) {
 	switch idpType {
 	case "github":
 		idpBuilder, err = buildGithubIdp(cmd, cluster, idpName)
+	case "gitlab":
+		idpBuilder, err = buildGitlabIdp(cmd, cluster, idpName)
 	case "google":
 		idpBuilder, err = buildGoogleIdp(cmd, cluster, idpName)
 	case "ldap":

--- a/cmd/create/idp/gitlab.go
+++ b/cmd/create/idp/gitlab.go
@@ -1,0 +1,160 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package idp
+
+import (
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/url"
+	"strings"
+
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	"github.com/spf13/cobra"
+
+	"github.com/openshift/moactl/pkg/interactive"
+)
+
+func buildGitlabIdp(cmd *cobra.Command,
+	cluster *cmv1.Cluster,
+	idpName string) (idpBuilder cmv1.IdentityProviderBuilder, err error) {
+	clientID := args.clientID
+	clientSecret := args.clientSecret
+	gitlabURL := args.gitlabURL
+
+	if interactive.Enabled() || !cmd.Flags().Changed("host-url") {
+		gitlabURL, err = interactive.GetString(interactive.Input{
+			Question: "URL",
+			Help:     cmd.Flags().Lookup("host-url").Usage,
+			Default:  gitlabURL,
+			Required: true,
+		})
+		if err != nil {
+			return idpBuilder, fmt.Errorf("Expected a valid GitLab provider URL: %s", err)
+		}
+	}
+	parsedIssuerURL, err := url.ParseRequestURI(gitlabURL)
+	if err != nil {
+		return idpBuilder, fmt.Errorf("Expected a valid GitLab provider URL: %s", err)
+	}
+	if parsedIssuerURL.Scheme != "https" {
+		return idpBuilder, errors.New("Expected GitLab provider URL to use an https:// scheme")
+	}
+	if parsedIssuerURL.RawQuery != "" {
+		return idpBuilder, errors.New("GitLab provider URL must not have query parameters")
+	}
+	if parsedIssuerURL.Fragment != "" {
+		return idpBuilder, errors.New("GitLab provider URL must not have a fragment")
+	}
+
+	if interactive.Enabled() || clientID == "" || clientSecret == "" {
+		instructionsURL := fmt.Sprintf("%s/profile/applications", gitlabURL)
+		consoleURL := cluster.Console().URL()
+		oauthURL := strings.Replace(consoleURL, "console-openshift-console", "oauth-openshift", 1)
+		err = interactive.PrintHelp(interactive.Help{
+			Message: "To use GitLab as an identity provider, register the application by opening:",
+			Steps:   []string{instructionsURL},
+		})
+		if err != nil {
+			return idpBuilder, err
+		}
+		err = interactive.PrintHelp(interactive.Help{
+			Message: "Then enter the following information:",
+			Steps: []string{
+				fmt.Sprintf("Name: %s", cluster.Name()),
+				fmt.Sprintf("Redirect URI: %s/oauth2callback/%s", oauthURL, idpName),
+				"Scopes: openid",
+			},
+		})
+		if err != nil {
+			return idpBuilder, err
+		}
+
+		clientID, err = interactive.GetString(interactive.Input{
+			Question: "Application ID",
+			Help:     "Paste the Application ID provided by GitLab when registering your application.",
+			Default:  clientID,
+			Required: true,
+		})
+		if err != nil {
+			return idpBuilder, errors.New("Expected a GitLab application Application ID")
+		}
+
+		if clientSecret == "" {
+			clientSecret, err = interactive.GetPassword(interactive.Input{
+				Question: "Secret",
+				Help:     "Paste the Secret provided by GitLab when registering your application.",
+				Required: true,
+			})
+			if err != nil {
+				return idpBuilder, errors.New("Expected a GitLab application Secret")
+			}
+		}
+	}
+
+	caPath := args.caPath
+	if interactive.Enabled() {
+		caPath, err = interactive.GetCert(interactive.Input{
+			Question: "CA file path",
+			Help:     cmd.Flags().Lookup("ca").Usage,
+			Default:  caPath,
+		})
+		if err != nil {
+			return idpBuilder, fmt.Errorf("Expected a valid certificate bundle: %s", err)
+		}
+	}
+	// Get certificate contents
+	ca := ""
+	if caPath != "" {
+		cert, err := ioutil.ReadFile(caPath)
+		if err != nil {
+			return idpBuilder, fmt.Errorf("Expected a valid certificate bundle: %s", err)
+		}
+		ca = string(cert)
+	}
+
+	mappingMethod := args.mappingMethod
+	if interactive.Enabled() {
+		mappingMethod, err = interactive.GetOption(interactive.Input{
+			Question: "Mapping method",
+			Help:     cmd.Flags().Lookup("mapping-method").Usage,
+			Options:  []string{"add", "claim", "generate", "lookup"},
+			Default:  mappingMethod,
+			Required: true,
+		})
+	}
+
+	// Create GitLab IDP
+	gitlabIDP := cmv1.NewGitlabIdentityProvider().
+		ClientID(clientID).
+		ClientSecret(clientSecret).
+		URL(gitlabURL)
+
+	// Set the CA file, if any
+	if ca != "" {
+		gitlabIDP = gitlabIDP.CA(ca)
+	}
+
+	// Create new IDP with GitLab provider
+	idpBuilder.
+		Type("GitlabIdentityProvider"). // FIXME: ocm-api-model has the wrong enum values
+		Name(idpName).
+		MappingMethod(cmv1.IdentityProviderMappingMethod(mappingMethod)).
+		Gitlab(gitlabIDP)
+
+	return
+}

--- a/cmd/list/idp/cmd.go
+++ b/cmd/list/idp/cmd.go
@@ -145,6 +145,8 @@ func getType(idp *cmv1.IdentityProvider) string {
 	switch idp.Type() {
 	case "GithubIdentityProvider":
 		return "GitHub"
+	case "GitlabIdentityProvider":
+		return "GitLab"
 	case "GoogleIdentityProvider":
 		return "Google"
 	case "LDAPIdentityProvider":

--- a/docs/moactl_create_idp.md
+++ b/docs/moactl_create_idp.md
@@ -24,7 +24,7 @@ moactl create idp [flags]
 
 ```
   -c, --cluster string               Name or ID of the cluster to add the IdP to (required).
-  -t, --type string                  Type of identity provider. Options are [github google ldap openid].
+  -t, --type string                  Type of identity provider. Options are [github gitlab google ldap openid].
       --name string                  Name for the identity provider.
                                      
       --mapping-method string        Specifies how new identities are mapped to users when they log in. (default "claim")
@@ -36,6 +36,7 @@ moactl create idp [flags]
       --organizations string         GitHub: Only users that are members of at least one of the listed organizations will be allowed to log in.
       --teams string                 GitHub: Only users that are members of at least one of the listed teams will be allowed to log in. The format is <org>/<team>.
                                      
+      --host-url string              GitLab: The host URL of a GitLab provider. (default "https://gitlab.com")
       --hosted-domain string         Google: Restrict users to a Google Apps domain.
                                      
       --url string                   LDAP: An RFC 2255 URL which specifies the LDAP search parameters to use.


### PR DESCRIPTION
To allow customers to authenticate into their clusters against GitLab,
we provide an IDP flow using the standard web application flow.

https://asciinema.org/a/VtNiqFZuzYFH5QgntxHdUEkWK