### PR TITLE
idp: Add support for certificate bundles

### DIFF
--- a/cmd/create/idp/cmd.go
+++ b/cmd/create/idp/cmd.go
@@ -41,6 +41,7 @@ var args struct {
 	clientID      string
 	clientSecret  string
 	mappingMethod string
+	caPath        string
 
 	// GitHub
 	githubHostname      string
@@ -124,7 +125,13 @@ func init() {
 		&args.clientSecret,
 		"client-secret",
 		"",
-		"Client Secret from the registered application.\n",
+		"Client Secret from the registered application.",
+	)
+	flags.StringVar(
+		&args.caPath,
+		"ca",
+		"",
+		"Path to PEM-encoded certificate file to use when making requests to the server.\n",
 	)
 
 	// GitHub

--- a/docs/moactl_create_idp.md
+++ b/docs/moactl_create_idp.md
@@ -30,6 +30,7 @@ moactl create idp [flags]
       --mapping-method string        Specifies how new identities are mapped to users when they log in. (default "claim")
       --client-id string             Client ID from the registered application.
       --client-secret string         Client Secret from the registered application.
+      --ca string                    Path to PEM-encoded certificate file to use when making requests to the server.
                                      
       --hostname string              GitHub: Optional domain to use with a hosted instance of GitHub Enterprise.
       --organizations string         GitHub: Only users that are members of at least one of the listed organizations will be allowed to log in.


### PR DESCRIPTION
When defining a custom hostname for the identity provider, we need to
support a ca-bundle file to be used when making requests to the server.

* https://asciinema.org/a/tSA28OuNKshJz1ihmIKox2MPJ
* https://asciinema.org/a/eWfw7AlgV4PwMQP8zKI7eMjfa
