### PR TITLE
aws: Add support for AWS profiles

### DIFF
--- a/docs/moactl.md
+++ b/docs/moactl.md
@@ -9,9 +9,10 @@ Command line tool for MOA.
 ### Options
 
 ```
-      --debug     Enable debug mode.
-  -h, --help      help for moactl
-  -v, --v Level   log level for V logs
+      --debug            Enable debug mode.
+  -h, --help             help for moactl
+      --profile string   Use a specific AWS profile from your credential file.
+  -v, --v Level          log level for V logs
 ```
 
 ### SEE ALSO

--- a/docs/moactl_completion.md
+++ b/docs/moactl_completion.md
@@ -27,8 +27,9 @@ moactl completion [flags]
 ### Options inherited from parent commands
 
 ```
-      --debug     Enable debug mode.
-  -v, --v Level   log level for V logs
+      --debug            Enable debug mode.
+      --profile string   Use a specific AWS profile from your credential file.
+  -v, --v Level          log level for V logs
 ```
 
 ### SEE ALSO

--- a/docs/moactl_create.md
+++ b/docs/moactl_create.md
@@ -16,8 +16,9 @@ Create a resource from stdin
 ### Options inherited from parent commands
 
 ```
-      --debug     Enable debug mode.
-  -v, --v Level   log level for V logs
+      --debug            Enable debug mode.
+      --profile string   Use a specific AWS profile from your credential file.
+  -v, --v Level          log level for V logs
 ```
 
 ### SEE ALSO

--- a/docs/moactl_create_cluster.md
+++ b/docs/moactl_create_cluster.md
@@ -43,9 +43,10 @@ moactl create cluster [flags]
 ### Options inherited from parent commands
 
 ```
-      --debug         Enable debug mode.
-  -i, --interactive   Enable interactive mode.
-  -v, --v Level       log level for V logs
+      --debug            Enable debug mode.
+  -i, --interactive      Enable interactive mode.
+      --profile string   Use a specific AWS profile from your credential file.
+  -v, --v Level          log level for V logs
 ```
 
 ### SEE ALSO

--- a/docs/moactl_create_idp.md
+++ b/docs/moactl_create_idp.md
@@ -56,9 +56,10 @@ moactl create idp [flags]
 ### Options inherited from parent commands
 
 ```
-      --debug         Enable debug mode.
-  -i, --interactive   Enable interactive mode.
-  -v, --v Level       log level for V logs
+      --debug            Enable debug mode.
+  -i, --interactive      Enable interactive mode.
+      --profile string   Use a specific AWS profile from your credential file.
+  -v, --v Level          log level for V logs
 ```
 
 ### SEE ALSO

--- a/docs/moactl_create_ingress.md
+++ b/docs/moactl_create_ingress.md
@@ -35,9 +35,10 @@ moactl create ingress [flags]
 ### Options inherited from parent commands
 
 ```
-      --debug         Enable debug mode.
-  -i, --interactive   Enable interactive mode.
-  -v, --v Level       log level for V logs
+      --debug            Enable debug mode.
+  -i, --interactive      Enable interactive mode.
+      --profile string   Use a specific AWS profile from your credential file.
+  -v, --v Level          log level for V logs
 ```
 
 ### SEE ALSO

--- a/docs/moactl_create_user.md
+++ b/docs/moactl_create_user.md
@@ -35,9 +35,10 @@ moactl create user [flags]
 ### Options inherited from parent commands
 
 ```
-      --debug         Enable debug mode.
-  -i, --interactive   Enable interactive mode.
-  -v, --v Level       log level for V logs
+      --debug            Enable debug mode.
+  -i, --interactive      Enable interactive mode.
+      --profile string   Use a specific AWS profile from your credential file.
+  -v, --v Level          log level for V logs
 ```
 
 ### SEE ALSO

--- a/docs/moactl_delete.md
+++ b/docs/moactl_delete.md
@@ -16,8 +16,9 @@ Delete a specific resource
 ### Options inherited from parent commands
 
 ```
-      --debug     Enable debug mode.
-  -v, --v Level   log level for V logs
+      --debug            Enable debug mode.
+      --profile string   Use a specific AWS profile from your credential file.
+  -v, --v Level          log level for V logs
 ```
 
 ### SEE ALSO

--- a/docs/moactl_delete_cluster.md
+++ b/docs/moactl_delete_cluster.md
@@ -31,9 +31,10 @@ moactl delete cluster [ID|NAME] [flags]
 ### Options inherited from parent commands
 
 ```
-      --debug     Enable debug mode.
-  -v, --v Level   log level for V logs
-  -y, --yes       Automatically answer yes to confirm operation.
+      --debug            Enable debug mode.
+      --profile string   Use a specific AWS profile from your credential file.
+  -v, --v Level          log level for V logs
+  -y, --yes              Automatically answer yes to confirm operation.
 ```
 
 ### SEE ALSO

--- a/docs/moactl_delete_idp.md
+++ b/docs/moactl_delete_idp.md
@@ -27,9 +27,10 @@ moactl delete idp [IDP NAME] [flags]
 ### Options inherited from parent commands
 
 ```
-      --debug     Enable debug mode.
-  -v, --v Level   log level for V logs
-  -y, --yes       Automatically answer yes to confirm operation.
+      --debug            Enable debug mode.
+      --profile string   Use a specific AWS profile from your credential file.
+  -v, --v Level          log level for V logs
+  -y, --yes              Automatically answer yes to confirm operation.
 ```
 
 ### SEE ALSO

--- a/docs/moactl_delete_ingress.md
+++ b/docs/moactl_delete_ingress.md
@@ -30,9 +30,10 @@ moactl delete ingress [flags]
 ### Options inherited from parent commands
 
 ```
-      --debug     Enable debug mode.
-  -v, --v Level   log level for V logs
-  -y, --yes       Automatically answer yes to confirm operation.
+      --debug            Enable debug mode.
+      --profile string   Use a specific AWS profile from your credential file.
+  -v, --v Level          log level for V logs
+  -y, --yes              Automatically answer yes to confirm operation.
 ```
 
 ### SEE ALSO

--- a/docs/moactl_delete_user.md
+++ b/docs/moactl_delete_user.md
@@ -35,9 +35,10 @@ moactl delete user [flags]
 ### Options inherited from parent commands
 
 ```
-      --debug     Enable debug mode.
-  -v, --v Level   log level for V logs
-  -y, --yes       Automatically answer yes to confirm operation.
+      --debug            Enable debug mode.
+      --profile string   Use a specific AWS profile from your credential file.
+  -v, --v Level          log level for V logs
+  -y, --yes              Automatically answer yes to confirm operation.
 ```
 
 ### SEE ALSO

--- a/docs/moactl_describe.md
+++ b/docs/moactl_describe.md
@@ -15,8 +15,9 @@ Show details of a specific resource
 ### Options inherited from parent commands
 
 ```
-      --debug     Enable debug mode.
-  -v, --v Level   log level for V logs
+      --debug            Enable debug mode.
+      --profile string   Use a specific AWS profile from your credential file.
+  -v, --v Level          log level for V logs
 ```
 
 ### SEE ALSO

--- a/docs/moactl_describe_cluster.md
+++ b/docs/moactl_describe_cluster.md
@@ -30,8 +30,9 @@ moactl describe cluster [ID|NAME] [flags]
 ### Options inherited from parent commands
 
 ```
-      --debug     Enable debug mode.
-  -v, --v Level   log level for V logs
+      --debug            Enable debug mode.
+      --profile string   Use a specific AWS profile from your credential file.
+  -v, --v Level          log level for V logs
 ```
 
 ### SEE ALSO

--- a/docs/moactl_download.md
+++ b/docs/moactl_download.md
@@ -15,8 +15,9 @@ Download necessary tools for using your cluster
 ### Options inherited from parent commands
 
 ```
-      --debug     Enable debug mode.
-  -v, --v Level   log level for V logs
+      --debug            Enable debug mode.
+      --profile string   Use a specific AWS profile from your credential file.
+  -v, --v Level          log level for V logs
 ```
 
 ### SEE ALSO

--- a/docs/moactl_download_openshift-client.md
+++ b/docs/moactl_download_openshift-client.md
@@ -26,8 +26,9 @@ moactl download openshift-client [flags]
 ### Options inherited from parent commands
 
 ```
-      --debug     Enable debug mode.
-  -v, --v Level   log level for V logs
+      --debug            Enable debug mode.
+      --profile string   Use a specific AWS profile from your credential file.
+  -v, --v Level          log level for V logs
 ```
 
 ### SEE ALSO

--- a/docs/moactl_edit.md
+++ b/docs/moactl_edit.md
@@ -16,8 +16,9 @@ Edit a specific resource
 ### Options inherited from parent commands
 
 ```
-      --debug     Enable debug mode.
-  -v, --v Level   log level for V logs
+      --debug            Enable debug mode.
+      --profile string   Use a specific AWS profile from your credential file.
+  -v, --v Level          log level for V logs
 ```
 
 ### SEE ALSO

--- a/docs/moactl_edit_cluster.md
+++ b/docs/moactl_edit_cluster.md
@@ -36,9 +36,10 @@ moactl edit cluster [flags]
 ### Options inherited from parent commands
 
 ```
-      --debug         Enable debug mode.
-  -i, --interactive   Enable interactive mode.
-  -v, --v Level       log level for V logs
+      --debug            Enable debug mode.
+  -i, --interactive      Enable interactive mode.
+      --profile string   Use a specific AWS profile from your credential file.
+  -v, --v Level          log level for V logs
 ```
 
 ### SEE ALSO

--- a/docs/moactl_edit_ingress.md
+++ b/docs/moactl_edit_ingress.md
@@ -35,9 +35,10 @@ moactl edit ingress [flags]
 ### Options inherited from parent commands
 
 ```
-      --debug         Enable debug mode.
-  -i, --interactive   Enable interactive mode.
-  -v, --v Level       log level for V logs
+      --debug            Enable debug mode.
+  -i, --interactive      Enable interactive mode.
+      --profile string   Use a specific AWS profile from your credential file.
+  -v, --v Level          log level for V logs
 ```
 
 ### SEE ALSO

--- a/docs/moactl_init.md
+++ b/docs/moactl_init.md
@@ -40,8 +40,9 @@ moactl init [flags]
 ### Options inherited from parent commands
 
 ```
-      --debug     Enable debug mode.
-  -v, --v Level   log level for V logs
+      --debug            Enable debug mode.
+      --profile string   Use a specific AWS profile from your credential file.
+  -v, --v Level          log level for V logs
 ```
 
 ### SEE ALSO

--- a/docs/moactl_list.md
+++ b/docs/moactl_list.md
@@ -15,8 +15,9 @@ List all resources of a specific type
 ### Options inherited from parent commands
 
 ```
-      --debug     Enable debug mode.
-  -v, --v Level   log level for V logs
+      --debug            Enable debug mode.
+      --profile string   Use a specific AWS profile from your credential file.
+  -v, --v Level          log level for V logs
 ```
 
 ### SEE ALSO

--- a/docs/moactl_list_clusters.md
+++ b/docs/moactl_list_clusters.md
@@ -27,8 +27,9 @@ moactl list clusters [flags]
 ### Options inherited from parent commands
 
 ```
-      --debug     Enable debug mode.
-  -v, --v Level   log level for V logs
+      --debug            Enable debug mode.
+      --profile string   Use a specific AWS profile from your credential file.
+  -v, --v Level          log level for V logs
 ```
 
 ### SEE ALSO

--- a/docs/moactl_list_idps.md
+++ b/docs/moactl_list_idps.md
@@ -27,8 +27,9 @@ moactl list idps [flags]
 ### Options inherited from parent commands
 
 ```
-      --debug     Enable debug mode.
-  -v, --v Level   log level for V logs
+      --debug            Enable debug mode.
+      --profile string   Use a specific AWS profile from your credential file.
+  -v, --v Level          log level for V logs
 ```
 
 ### SEE ALSO

--- a/docs/moactl_list_ingresses.md
+++ b/docs/moactl_list_ingresses.md
@@ -27,8 +27,9 @@ moactl list ingresses [flags]
 ### Options inherited from parent commands
 
 ```
-      --debug     Enable debug mode.
-  -v, --v Level   log level for V logs
+      --debug            Enable debug mode.
+      --profile string   Use a specific AWS profile from your credential file.
+  -v, --v Level          log level for V logs
 ```
 
 ### SEE ALSO

--- a/docs/moactl_list_regions.md
+++ b/docs/moactl_list_regions.md
@@ -27,8 +27,9 @@ moactl list regions [flags]
 ### Options inherited from parent commands
 
 ```
-      --debug     Enable debug mode.
-  -v, --v Level   log level for V logs
+      --debug            Enable debug mode.
+      --profile string   Use a specific AWS profile from your credential file.
+  -v, --v Level          log level for V logs
 ```
 
 ### SEE ALSO

--- a/docs/moactl_list_users.md
+++ b/docs/moactl_list_users.md
@@ -27,8 +27,9 @@ moactl list users [flags]
 ### Options inherited from parent commands
 
 ```
-      --debug     Enable debug mode.
-  -v, --v Level   log level for V logs
+      --debug            Enable debug mode.
+      --profile string   Use a specific AWS profile from your credential file.
+  -v, --v Level          log level for V logs
 ```
 
 ### SEE ALSO

--- a/docs/moactl_list_versions.md
+++ b/docs/moactl_list_versions.md
@@ -27,8 +27,9 @@ moactl list versions [flags]
 ### Options inherited from parent commands
 
 ```
-      --debug     Enable debug mode.
-  -v, --v Level   log level for V logs
+      --debug            Enable debug mode.
+      --profile string   Use a specific AWS profile from your credential file.
+  -v, --v Level          log level for V logs
 ```
 
 ### SEE ALSO

--- a/docs/moactl_login.md
+++ b/docs/moactl_login.md
@@ -44,8 +44,9 @@ moactl login [flags]
 ### Options inherited from parent commands
 
 ```
-      --debug     Enable debug mode.
-  -v, --v Level   log level for V logs
+      --debug            Enable debug mode.
+      --profile string   Use a specific AWS profile from your credential file.
+  -v, --v Level          log level for V logs
 ```
 
 ### SEE ALSO

--- a/docs/moactl_logout.md
+++ b/docs/moactl_logout.md
@@ -19,8 +19,9 @@ moactl logout [flags]
 ### Options inherited from parent commands
 
 ```
-      --debug     Enable debug mode.
-  -v, --v Level   log level for V logs
+      --debug            Enable debug mode.
+      --profile string   Use a specific AWS profile from your credential file.
+  -v, --v Level          log level for V logs
 ```
 
 ### SEE ALSO

--- a/docs/moactl_logs.md
+++ b/docs/moactl_logs.md
@@ -15,8 +15,9 @@ Show installation or uninstallation logs for a cluster
 ### Options inherited from parent commands
 
 ```
-      --debug     Enable debug mode.
-  -v, --v Level   log level for V logs
+      --debug            Enable debug mode.
+      --profile string   Use a specific AWS profile from your credential file.
+  -v, --v Level          log level for V logs
 ```
 
 ### SEE ALSO

--- a/docs/moactl_logs_install.md
+++ b/docs/moactl_logs_install.md
@@ -32,8 +32,9 @@ moactl logs install [ID|NAME] [flags]
 ### Options inherited from parent commands
 
 ```
-      --debug     Enable debug mode.
-  -v, --v Level   log level for V logs
+      --debug            Enable debug mode.
+      --profile string   Use a specific AWS profile from your credential file.
+  -v, --v Level          log level for V logs
 ```
 
 ### SEE ALSO

--- a/docs/moactl_logs_uninstall.md
+++ b/docs/moactl_logs_uninstall.md
@@ -32,8 +32,9 @@ moactl logs uninstall [ID|NAME] [flags]
 ### Options inherited from parent commands
 
 ```
-      --debug     Enable debug mode.
-  -v, --v Level   log level for V logs
+      --debug            Enable debug mode.
+      --profile string   Use a specific AWS profile from your credential file.
+  -v, --v Level          log level for V logs
 ```
 
 ### SEE ALSO

--- a/docs/moactl_verify.md
+++ b/docs/moactl_verify.md
@@ -16,8 +16,9 @@ Verify resources are configured correctly for cluster install
 ### Options inherited from parent commands
 
 ```
-      --debug     Enable debug mode.
-  -v, --v Level   log level for V logs
+      --debug            Enable debug mode.
+      --profile string   Use a specific AWS profile from your credential file.
+  -v, --v Level          log level for V logs
 ```
 
 ### SEE ALSO

--- a/docs/moactl_verify_openshift-client.md
+++ b/docs/moactl_verify_openshift-client.md
@@ -26,9 +26,10 @@ moactl verify openshift-client [flags]
 ### Options inherited from parent commands
 
 ```
-      --debug           Enable debug mode.
-  -r, --region string   AWS region in which to run (overrides the AWS_REGION environment variable)
-  -v, --v Level         log level for V logs
+      --debug            Enable debug mode.
+      --profile string   Use a specific AWS profile from your credential file.
+  -r, --region string    AWS region in which to run (overrides the AWS_REGION environment variable)
+  -v, --v Level          log level for V logs
 ```
 
 ### SEE ALSO

--- a/docs/moactl_verify_permissions.md
+++ b/docs/moactl_verify_permissions.md
@@ -29,9 +29,10 @@ moactl verify permissions [flags]
 ### Options inherited from parent commands
 
 ```
-      --debug           Enable debug mode.
-  -r, --region string   AWS region in which to run (overrides the AWS_REGION environment variable)
-  -v, --v Level         log level for V logs
+      --debug            Enable debug mode.
+      --profile string   Use a specific AWS profile from your credential file.
+  -r, --region string    AWS region in which to run (overrides the AWS_REGION environment variable)
+  -v, --v Level          log level for V logs
 ```
 
 ### SEE ALSO

--- a/docs/moactl_verify_quota.md
+++ b/docs/moactl_verify_quota.md
@@ -29,9 +29,10 @@ moactl verify quota [flags]
 ### Options inherited from parent commands
 
 ```
-      --debug           Enable debug mode.
-  -r, --region string   AWS region in which to run (overrides the AWS_REGION environment variable)
-  -v, --v Level         log level for V logs
+      --debug            Enable debug mode.
+      --profile string   Use a specific AWS profile from your credential file.
+  -r, --region string    AWS region in which to run (overrides the AWS_REGION environment variable)
+  -v, --v Level          log level for V logs
 ```
 
 ### SEE ALSO

--- a/docs/moactl_version.md
+++ b/docs/moactl_version.md
@@ -19,8 +19,9 @@ moactl version [flags]
 ### Options inherited from parent commands
 
 ```
-      --debug     Enable debug mode.
-  -v, --v Level   log level for V logs
+      --debug            Enable debug mode.
+      --profile string   Use a specific AWS profile from your credential file.
+  -v, --v Level          log level for V logs
 ```
 
 ### SEE ALSO

--- a/docs/moactl_whoami.md
+++ b/docs/moactl_whoami.md
@@ -26,8 +26,9 @@ moactl whoami [flags]
 ### Options inherited from parent commands
 
 ```
-      --debug     Enable debug mode.
-  -v, --v Level   log level for V logs
+      --debug            Enable debug mode.
+      --profile string   Use a specific AWS profile from your credential file.
+  -v, --v Level          log level for V logs
 ```
 
 ### SEE ALSO

--- a/main.go
+++ b/main.go
@@ -56,6 +56,7 @@ func init() {
 	// Add the command line flags:
 	fs := root.PersistentFlags()
 	arguments.AddDebugFlag(fs)
+	arguments.AddProfileFlag(fs)
 
 	// Register the subcommands:
 	root.AddCommand(completion.Cmd)

--- a/pkg/aws/client.go
+++ b/pkg/aws/client.go
@@ -40,6 +40,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/sts/stsiface"
 	"github.com/sirupsen/logrus"
 
+	"github.com/openshift/moactl/pkg/aws/profile"
 	"github.com/openshift/moactl/pkg/aws/tags"
 	"github.com/openshift/moactl/pkg/logging"
 )
@@ -139,6 +140,7 @@ func (b *ClientBuilder) Build() (Client, error) {
 	// Create the AWS session:
 	sess, err := session.NewSessionWithOptions(session.Options{
 		SharedConfigState: session.SharedConfigEnable,
+		Profile:           profile.Profile(),
 		Config: aws.Config{
 			Region: b.region,
 			// MaxRetries to limit the number of attempts on failed API calls
@@ -174,6 +176,9 @@ func (b *ClientBuilder) Build() (Client, error) {
 	region := aws.StringValue(sess.Config.Region)
 	if region == "" {
 		return nil, fmt.Errorf("Region is not set")
+	}
+	if profile.Profile() != "" {
+		b.logger.Debugf("Using AWS profile: %s", profile.Profile())
 	}
 
 	// Check that the AWS credentials are available:

--- a/pkg/aws/profile/flag.go
+++ b/pkg/aws/profile/flag.go
@@ -14,23 +14,28 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// This file contains functions that add common arguments to the command line.
+// This file contains functions used to implement the '--profile' command line option.
 
-package arguments
+package profile
 
 import (
 	"github.com/spf13/pflag"
-
-	"github.com/openshift/moactl/pkg/aws/profile"
-	"github.com/openshift/moactl/pkg/debug"
 )
 
-// AddDebugFlag adds the '--debug' flag to the given set of command line flags.
-func AddDebugFlag(fs *pflag.FlagSet) {
-	debug.AddFlag(fs)
+// AddFlag adds the debug flag to the given set of command line flags.
+func AddFlag(flags *pflag.FlagSet) {
+	flags.StringVar(
+		&profile,
+		"profile",
+		"",
+		"Use a specific AWS profile from your credential file.",
+	)
 }
 
-// AddProfileFlag adds the '--profile' flag to the given set of command line flags.
-func AddProfileFlag(fs *pflag.FlagSet) {
-	profile.AddFlag(fs)
+// Enabled retursn a boolean flag that indicates if the debug mode is enabled.
+func Profile() string {
+	return profile
 }
+
+// enabled is a boolean flag that indicates that the debug mode is enabled.
+var profile string


### PR DESCRIPTION
We enable the --profile flag to all commands, which then authenticates
against AWS using that profile from the configuration.