### PR TITLE
Support dry-run parameter for 'init' and 'create cluster'

### DIFF
--- a/docs/moactl_create_cluster.md
+++ b/docs/moactl_create_cluster.md
@@ -36,6 +36,7 @@ moactl create cluster [flags]
       --host-prefix int               Subnet prefix length to assign to each individual node. For example, if host prefix is set to "23", then each node is assigned a /23 subnet out of the given CIDR.
       --private                       Restrict master API endpoint and application routes to direct, private connectivity.
       --watch                         Watch cluster installation logs.
+      --dry-run                       Simulate creating the cluster.
       --use-paid-ami                  Whether to use the paid AMI from AWS. Requires a valid subscription to the MOA Product.
   -h, --help                          help for cluster
 ```

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/briandowns/spinner v1.11.1
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/dustin/go-humanize v1.0.0
+	github.com/go-bindata/go-bindata v3.1.2+incompatible // indirect
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
 	github.com/golang/mock v1.4.3
 	github.com/mattn/go-colorable v0.1.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -92,6 +92,9 @@ github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
+github.com/go-bindata/go-bindata v1.0.0 h1:DZ34txDXWn1DyWa+vQf7V9ANc2ILTtrEjtlsdJRF26M=
+github.com/go-bindata/go-bindata v3.1.2+incompatible h1:5vjJMVhowQdPzjE1LdxyFF7YFTXg5IgGVW4gBr5IbvE=
+github.com/go-bindata/go-bindata v3.1.2+incompatible/go.mod h1:xK8Dsgwmeed+BBsSy2XTopBn/8uK2HWuGSnA11C3Joo=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-kit/kit v0.9.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-kit/kit v0.10.0/go.mod h1:xUsJbQ/Fp4kEt7AFgCuvyX4a71u8h9jB8tj/ORgOZ7o=

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -62,6 +62,9 @@ type Spec struct {
 
 	// Access control config
 	ClusterAdmins *bool
+
+	// Simulate creating a cluster but don't actually create it
+	DryRun *bool
 }
 
 func IsValidClusterKey(clusterKey string) bool {
@@ -110,9 +113,12 @@ func CreateCluster(client *cmv1.ClustersClient, config Spec) (*cmv1.Cluster, err
 		return nil, fmt.Errorf("Unable to create cluster spec: %v", err)
 	}
 
-	cluster, err := client.Add().Body(spec).Send()
+	cluster, err := client.Add().Parameter("dryRun", *config.DryRun).Body(spec).Send()
 	if err != nil {
 		return nil, fmt.Errorf("Error creating cluster in OCM: %v", err)
+	}
+	if config.DryRun != nil && *config.DryRun {
+		return nil, nil
 	}
 
 	clusterObject := cluster.Body()


### PR DESCRIPTION
* create-cluster: Add --dry-run flag   
    With the dry-run flag we allow the customer to simulate creating
    a cluster. This runs through the entire process of validating, preflight
    and quota checks and returns with either success or error. The cluster
    is not persisted nor written to the OCM database.
* init: Simulate cluster creation
    To ensure that a customer has all necessary permissions and quota in
    their OCM account, we attempt creating a very basic cluster with the
    dry-run flag and warn the customer in case of failuer.
