### PR TITLE
Add CONTRIBUTING.md file, with some details about CI

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,12 @@
+# Questions?
+
+If you have any questions about the code or how to contribute, don't hesitate to
+[open an issue](https://github.com/openshift/moactl/issues/new) in this repo.
+
+## CI
+
+This repository is using Prow CI running at https://prow.ci.openshift.org/,
+configured in https://github.com/openshift/release repo.
+
+`.golangciversion` file is read by the `lint` job commands there:
+https://github.com/openshift/release/blob/master/ci-operator/config/openshift/moactl/openshift-moactl-master.yaml


### PR DESCRIPTION
Actually all I wanted is document where the `.golangciversion` file gets used (not mentioned anywhere inside this repo) :grin: 