### PR TITLE
Release v0.0.14

### DIFF
--- a/CHANGES.adoc
+++ b/CHANGES.adoc
@@ -3,6 +3,17 @@
 This document describes the relevant changes between releases of the `moactl`
 command line tool.
 
+== 0.0.14 Oct 8 2020
+
+- idp: Add support for certificate bundles
+- Added New Error Message Implementation
+- Updated OCM SDK version
+- idp: Add support for GitLab
+- create-cluster: Add --dry-run flag
+- init: Simulate cluster creation
+- Makefile: only download go-bindata when not available
+- Move main.go to moactl directory, add make install target
+
 == 0.0.13 Sep 30 2020
 
 - Add Provision Type and Reason for error cluster

--- a/pkg/info/info.go
+++ b/pkg/info/info.go
@@ -18,4 +18,4 @@ limitations under the License.
 
 package info
 
-const Version = "0.0.13"
+const Version = "0.0.14"


### PR DESCRIPTION
- idp: Add support for certificate bundles
- Added New Error Message Implementation
- Updated OCM SDK version
- idp: Add support for GitLab
- create-cluster: Add --dry-run flag
- init: Simulate cluster creation
- Makefile: only download go-bindata when not available
- Move main.go to moactl directory, add make install target