### PR TITLE
init: Ensure osdCcsAdmin exists before attempting cluster dry-run

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -507,7 +507,7 @@ func run(cmd *cobra.Command, _ []string) {
 	cluster, err := clusterprovider.CreateCluster(ocmClient.Clusters(), clusterConfig)
 	if err != nil {
 		if args.dryRun {
-			reporter.Errorf("Creating cluster '%s' would have failed: %s", clusterName, err)
+			reporter.Errorf("Creating cluster '%s' should fail: %s", clusterName, err)
 		} else {
 			reporter.Errorf("Failed to create cluster: %s", err)
 		}
@@ -516,7 +516,7 @@ func run(cmd *cobra.Command, _ []string) {
 
 	if args.dryRun {
 		reporter.Infof(
-			"Creating cluster '%s' would have succeeded. Run without the '--dry-run' flag to create the cluster.",
+			"Creating cluster '%s' should succeed. Run without the '--dry-run' flag to create the cluster.",
 			clusterName)
 		os.Exit(0)
 	}

--- a/cmd/initialize/cmd.go
+++ b/cmd/initialize/cmd.go
@@ -193,16 +193,6 @@ func run(cmd *cobra.Command, argv []string) {
 	// Call `verify quota` as part of init
 	quota.Cmd.Run(cmd, argv)
 
-	// Check whether the user can create a basic cluster
-	reporter.Infof("Running cluster simulation...")
-	err = simulateCluster(clustersCollection, args.region)
-	if err != nil {
-		reporter.Warnf("Cluster simulation failed. "+
-			"If you try to create a cluster, it will likely fail with an error similar to:\n%s", err)
-	} else {
-		reporter.Infof("Cluster simulation successful")
-	}
-
 	// Ensure that there is an AWS user to create all the resources needed by the cluster:
 	reporter.Infof("Ensuring cluster administrator user '%s'...", aws.AdminUserName)
 	created, err := client.EnsureOsdCcsAdminUser(aws.OsdCcsAdminStackName)
@@ -214,6 +204,16 @@ func run(cmd *cobra.Command, argv []string) {
 		reporter.Infof("Admin user '%s' created successfully!", aws.AdminUserName)
 	} else {
 		reporter.Infof("Admin user '%s' already exists!", aws.AdminUserName)
+	}
+
+	// Check whether the user can create a basic cluster
+	reporter.Infof("Validating cluster creation...")
+	err = simulateCluster(clustersCollection, args.region)
+	if err != nil {
+		reporter.Warnf("Cluster creation failed. "+
+			"If you create a cluster, it should fail with the following error:\n%s", err)
+	} else {
+		reporter.Infof("Cluster creation valid")
 	}
 
 	oc.Cmd.Run(cmd, argv)


### PR DESCRIPTION
If the osdCcsAdmin user does not exist, the dry-run will always fail. We
should always ensure that the cloudformation stack is set before
attempting a cluster install.