### PR TITLE
cluster: Add flag to disable SCP checks

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -53,6 +53,9 @@ var args struct {
 	// Whether to use the AMI image override from the AWS marketplace
 	usePaidAMI bool
 
+	// Disable SCP checks in the installer
+	disableSCPChecks bool
+
 	// Basic options
 	private            bool
 	multiAZ            bool
@@ -193,6 +196,13 @@ func init() {
 		"private",
 		false,
 		"Restrict master API endpoint and application routes to direct, private connectivity.",
+	)
+
+	flags.BoolVar(
+		&args.disableSCPChecks,
+		"disable-scp-checks",
+		false,
+		"Indicates if cloud permission checks are disabled when attempting installation of the cluster.",
 	)
 
 	flags.BoolVar(
@@ -495,6 +505,7 @@ func run(cmd *cobra.Command, _ []string) {
 		HostPrefix:         hostPrefix,
 		Private:            &private,
 		DryRun:             &args.dryRun,
+		DisableSCPChecks:   &args.disableSCPChecks,
 	}
 
 	// If the flag is explicitly set to false, OCM will tell the cluster provisioner

--- a/docs/moactl_create_cluster.md
+++ b/docs/moactl_create_cluster.md
@@ -35,6 +35,7 @@ moactl create cluster [flags]
       --pod-cidr ipNet                Block of IP addresses from which Pod IP addresses are allocated, for example "10.128.0.0/14".
       --host-prefix int               Subnet prefix length to assign to each individual node. For example, if host prefix is set to "23", then each node is assigned a /23 subnet out of the given CIDR.
       --private                       Restrict master API endpoint and application routes to direct, private connectivity.
+      --disable-scp-checks            Indicates if cloud permission checks are disabled when attempting installation of the cluster.
       --watch                         Watch cluster installation logs.
       --dry-run                       Simulate creating the cluster.
   -h, --help                          help for cluster

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -65,6 +65,9 @@ type Spec struct {
 
 	// Simulate creating a cluster but don't actually create it
 	DryRun *bool
+
+	// Disable SCP checks in the installer by setting credentials mode as mint
+	DisableSCPChecks *bool
 }
 
 func IsValidClusterKey(clusterKey string) bool {
@@ -394,6 +397,10 @@ func createClusterSpec(config Spec, awsClient aws.Client) (*cmv1.Cluster, error)
 					Listening(cmv1.ListeningMethodExternal),
 			)
 		}
+	}
+
+	if config.DisableSCPChecks != nil && *config.DisableSCPChecks {
+		clusterBuilder = clusterBuilder.CCS(cmv1.NewCCS().DisableSCPChecks(true))
 	}
 
 	clusterSpec, err := clusterBuilder.Build()


### PR DESCRIPTION
This flag indicates if cloud permission checks are disabled when
attempting installation of the cluster by setting mint credential mode
in the installer config.