### PR TITLE
ocm: Keep error opIds and codes behind debug flag

### DIFF
--- a/cmd/create/idp/cmd.go
+++ b/cmd/create/idp/cmd.go
@@ -400,13 +400,14 @@ func run(cmd *cobra.Command, _ []string) {
 		os.Exit(1)
 	}
 
-	_, err = clustersCollection.Cluster(cluster.ID()).
+	res, err := clustersCollection.Cluster(cluster.ID()).
 		IdentityProviders().
 		Add().
 		Body(idp).
 		Send()
 	if err != nil {
-		reporter.Errorf("Failed to add IDP to cluster '%s': %v", clusterKey, err)
+		reporter.Debugf(err.Error())
+		reporter.Errorf("Failed to add IDP to cluster '%s': %s", clusterKey, res.Error().Reason())
 		os.Exit(1)
 	}
 

--- a/cmd/create/ingress/cmd.go
+++ b/cmd/create/ingress/cmd.go
@@ -170,13 +170,14 @@ func run(cmd *cobra.Command, _ []string) {
 		os.Exit(1)
 	}
 
-	_, err = clustersCollection.Cluster(cluster.ID()).
+	res, err := clustersCollection.Cluster(cluster.ID()).
 		Ingresses().
 		Add().
 		Body(ingress).
 		Send()
 	if err != nil {
-		reporter.Errorf("Failed to add ingress to cluster '%s': %v", clusterKey, err)
+		reporter.Debugf(err.Error())
+		reporter.Errorf("Failed to add ingress to cluster '%s': %s", clusterKey, res.Error().Reason())
 		os.Exit(1)
 	}
 }

--- a/cmd/create/user/cmd.go
+++ b/cmd/create/user/cmd.go
@@ -171,7 +171,7 @@ func run(_ *cobra.Command, _ []string) {
 				reporter.Errorf("Failed to create cluster-admin user '%s' for cluster '%s'", username, clusterKey)
 				continue
 			}
-			_, err = clustersCollection.Cluster(cluster.ID()).
+			res, err := clustersCollection.Cluster(cluster.ID()).
 				Groups().
 				Group("cluster-admins").
 				Users().
@@ -179,7 +179,9 @@ func run(_ *cobra.Command, _ []string) {
 				Body(user).
 				Send()
 			if err != nil {
-				reporter.Errorf("Failed to add cluster-admin user '%s' to cluster '%s': %v", username, clusterKey, err)
+				reporter.Debugf(err.Error())
+				reporter.Errorf("Failed to add cluster-admin user '%s' to cluster '%s': %s",
+					username, clusterKey, res.Error().Reason())
 				continue
 			}
 		}
@@ -193,7 +195,7 @@ func run(_ *cobra.Command, _ []string) {
 				reporter.Errorf("Failed to create dedicated-admin user '%s' for cluster '%s'", username, clusterKey)
 				continue
 			}
-			_, err = clustersCollection.Cluster(cluster.ID()).
+			res, err := clustersCollection.Cluster(cluster.ID()).
 				Groups().
 				Group("dedicated-admins").
 				Users().
@@ -201,7 +203,9 @@ func run(_ *cobra.Command, _ []string) {
 				Body(user).
 				Send()
 			if err != nil {
-				reporter.Errorf("Failed to add dedicated-admin user '%s' to cluster '%s': %v", username, clusterKey, err)
+				reporter.Debugf(err.Error())
+				reporter.Errorf("Failed to add dedicated-admin user '%s' to cluster '%s': %s",
+					username, clusterKey, res.Error().Reason())
 				continue
 			}
 		}

--- a/cmd/dlt/idp/cmd.go
+++ b/cmd/dlt/idp/cmd.go
@@ -149,14 +149,16 @@ func run(_ *cobra.Command, argv []string) {
 
 	if confirm.Confirm("delete identity provider %s on cluster %s", idpName, clusterKey) {
 		reporter.Debugf("Deleting identity provider '%s' on cluster '%s'", idpName, clusterKey)
-		_, err = clustersCollection.
+		res, err := clustersCollection.
 			Cluster(cluster.ID()).
 			IdentityProviders().
 			IdentityProvider(idp.ID()).
 			Delete().
 			Send()
 		if err != nil {
-			reporter.Errorf("Failed to delete identity provider '%s' on cluster '%s'", idpName, clusterKey)
+			reporter.Debugf(err.Error())
+			reporter.Errorf("Failed to delete identity provider '%s' on cluster '%s': %s",
+				idpName, clusterKey, res.Error().Reason())
 			os.Exit(1)
 		}
 	}

--- a/cmd/dlt/ingress/cmd.go
+++ b/cmd/dlt/ingress/cmd.go
@@ -165,14 +165,16 @@ func run(_ *cobra.Command, argv []string) {
 
 	if confirm.Confirm("delete ingress %s on cluster %s", ingressID, clusterKey) {
 		reporter.Debugf("Deleting ingress '%s' on cluster '%s'", ingress.ID(), clusterKey)
-		_, err = clustersCollection.
+		res, err := clustersCollection.
 			Cluster(cluster.ID()).
 			Ingresses().
 			Ingress(ingress.ID()).
 			Delete().
 			Send()
 		if err != nil {
-			reporter.Errorf("Failed to delete ingress '%s' on cluster '%s'", ingress.ID(), clusterKey)
+			reporter.Debugf(err.Error())
+			reporter.Errorf("Failed to delete ingress '%s' on cluster '%s': %s",
+				ingress.ID(), clusterKey, res.Error().Reason())
 			os.Exit(1)
 		}
 	}

--- a/cmd/dlt/user/cmd.go
+++ b/cmd/dlt/user/cmd.go
@@ -166,7 +166,7 @@ func run(_ *cobra.Command, _ []string) {
 	if clusterAdmins != "" {
 		reporter.Debugf("Deleting cluster-admin users from cluster '%s'", clusterKey)
 		for _, username := range strings.Split(clusterAdmins, ",") {
-			_, err = clustersCollection.Cluster(cluster.ID()).
+			res, err := clustersCollection.Cluster(cluster.ID()).
 				Groups().
 				Group("cluster-admins").
 				Users().
@@ -174,7 +174,9 @@ func run(_ *cobra.Command, _ []string) {
 				Delete().
 				Send()
 			if err != nil {
-				reporter.Errorf("Failed to delete cluster-admin user '%s' from cluster '%s': %v", username, clusterKey, err)
+				reporter.Debugf(err.Error())
+				reporter.Errorf("Failed to delete cluster-admin user '%s' from cluster '%s': %s",
+					username, clusterKey, res.Error().Reason())
 				continue
 			}
 		}
@@ -183,7 +185,7 @@ func run(_ *cobra.Command, _ []string) {
 	if dedicatedAdmins != "" {
 		reporter.Debugf("Deleting dedicated-admin users from cluster '%s'", clusterKey)
 		for _, username := range strings.Split(dedicatedAdmins, ",") {
-			_, err = clustersCollection.Cluster(cluster.ID()).
+			res, err := clustersCollection.Cluster(cluster.ID()).
 				Groups().
 				Group("dedicated-admins").
 				Users().
@@ -191,7 +193,9 @@ func run(_ *cobra.Command, _ []string) {
 				Delete().
 				Send()
 			if err != nil {
-				reporter.Errorf("Failed to delete dedicated-admin user '%s' from cluster '%s': %v", username, clusterKey, err)
+				reporter.Debugf(err.Error())
+				reporter.Errorf("Failed to delete dedicated-admin user '%s' from cluster '%s': %s",
+					username, clusterKey, res.Error().Reason())
 				continue
 			}
 		}

--- a/cmd/edit/ingress/cmd.go
+++ b/cmd/edit/ingress/cmd.go
@@ -239,7 +239,7 @@ func run(cmd *cobra.Command, argv []string) {
 	}
 
 	reporter.Debugf("Updating ingress '%s' on cluster '%s'", ingress.ID(), clusterKey)
-	_, err = clustersCollection.
+	res, err := clustersCollection.
 		Cluster(cluster.ID()).
 		Ingresses().
 		Ingress(ingress.ID()).
@@ -247,8 +247,9 @@ func run(cmd *cobra.Command, argv []string) {
 		Body(ingress).
 		Send()
 	if err != nil {
-		reporter.Errorf("Failed to update ingress '%s' on cluster '%s': %v",
-			ingress.ID(), clusterKey, err)
+		reporter.Debugf(err.Error())
+		reporter.Errorf("Failed to update ingress '%s' on cluster '%s': %s",
+			ingress.ID(), clusterKey, res.Error().Reason())
 		os.Exit(1)
 	}
 }

--- a/cmd/whoami/cmd.go
+++ b/cmd/whoami/cmd.go
@@ -109,10 +109,11 @@ func run(_ *cobra.Command, _ []string) {
 	useTokenData := false
 	response, err := connection.AccountsMgmt().V1().CurrentAccount().Get().Send()
 	if err != nil {
+		reporter.Debugf(err.Error())
 		if response.Status() == http.StatusNotFound {
 			useTokenData = true
 		} else {
-			reporter.Errorf("Failed to get current account: %v", err)
+			reporter.Errorf("Failed to get current account: %s", response.Error().Reason())
 			os.Exit(1)
 		}
 	}

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -79,7 +79,7 @@ func HasClusters(client *cmv1.ClustersClient, creatorARN string) (bool, error) {
 		Size(1).
 		Send()
 	if err != nil {
-		return false, fmt.Errorf("Failed to list clusters: %v", err)
+		return false, fmt.Errorf(response.Error().Reason())
 	}
 
 	return response.Total() > 0, nil
@@ -115,7 +115,7 @@ func CreateCluster(client *cmv1.ClustersClient, config Spec) (*cmv1.Cluster, err
 
 	cluster, err := client.Add().Parameter("dryRun", *config.DryRun).Body(spec).Send()
 	if err != nil {
-		return nil, fmt.Errorf("Error creating cluster in OCM: %v", err)
+		return nil, fmt.Errorf(cluster.Error().Reason())
 	}
 	if config.DryRun != nil && *config.DryRun {
 		return nil, nil
@@ -167,7 +167,7 @@ func GetCluster(client *cmv1.ClustersClient, clusterKey string, creatorARN strin
 		Size(1).
 		Send()
 	if err != nil {
-		return nil, fmt.Errorf("Failed to locate cluster '%s': %v", clusterKey, err)
+		return nil, fmt.Errorf(response.Error().Reason())
 	}
 
 	switch response.Total() {
@@ -226,9 +226,9 @@ func UpdateCluster(client *cmv1.ClustersClient, clusterKey string, creatorARN st
 		return err
 	}
 
-	_, err = client.Cluster(cluster.ID()).Update().Body(clusterSpec).Send()
+	response, err := client.Cluster(cluster.ID()).Update().Body(clusterSpec).Send()
 	if err != nil {
-		return err
+		return fmt.Errorf(response.Error().Reason())
 	}
 
 	return nil
@@ -240,9 +240,9 @@ func DeleteCluster(client *cmv1.ClustersClient, clusterKey string, creatorARN st
 		return nil, err
 	}
 
-	_, err = client.Cluster(cluster.ID()).Delete().Send()
+	response, err := client.Cluster(cluster.ID()).Delete().Send()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf(response.Error().Reason())
 	}
 
 	return cluster, nil
@@ -261,9 +261,9 @@ func InstallAddOn(client *cmv1.ClustersClient, clusterKey string, creatorARN str
 		return err
 	}
 
-	_, err = client.Cluster(cluster.ID()).Addons().Add().Body(addOnInstallation).Send()
+	response, err := client.Cluster(cluster.ID()).Addons().Add().Body(addOnInstallation).Send()
 	if err != nil {
-		return err
+		return fmt.Errorf(response.Error().Reason())
 	}
 
 	return nil

--- a/pkg/ocm/helpers.go
+++ b/pkg/ocm/helpers.go
@@ -43,7 +43,7 @@ func HasClusters(client *cmv1.ClustersClient, creatorARN string) (bool, error) {
 		Size(1).
 		Send()
 	if err != nil {
-		return false, fmt.Errorf("Failed to list clusters: %v", err)
+		return false, fmt.Errorf(response.Error().Reason())
 	}
 
 	return response.Total() > 0, nil
@@ -60,7 +60,7 @@ func GetCluster(client *cmv1.ClustersClient, clusterKey string, creatorARN strin
 		Size(1).
 		Send()
 	if err != nil {
-		return nil, fmt.Errorf("Failed to locate cluster '%s': %v", clusterKey, err)
+		return nil, fmt.Errorf(response.Error().Reason())
 	}
 
 	switch response.Total() {
@@ -80,7 +80,7 @@ func GetIdentityProviders(client *cmv1.ClustersClient, clusterID string) ([]*cmv
 		Size(-1).
 		Send()
 	if err != nil {
-		return nil, fmt.Errorf("Failed to get identity providers for cluster '%s': %v", clusterID, err)
+		return nil, fmt.Errorf(response.Error().Reason())
 	}
 
 	return response.Items().Slice(), nil
@@ -93,7 +93,7 @@ func GetIngresses(client *cmv1.ClustersClient, clusterID string) ([]*cmv1.Ingres
 		Size(-1).
 		Send()
 	if err != nil {
-		return nil, fmt.Errorf("Failed to get ingresses for cluster '%s': %v", clusterID, err)
+		return nil, fmt.Errorf(response.Error().Reason())
 	}
 
 	return response.Items().Slice(), nil
@@ -106,18 +106,18 @@ func GetUsers(client *cmv1.ClustersClient, clusterID string, group string) ([]*c
 		Size(-1).
 		Send()
 	if err != nil {
-		return nil, fmt.Errorf("Failed to get %s users for cluster '%s': %v", group, clusterID, err)
+		return nil, fmt.Errorf(response.Error().Reason())
 	}
 
 	return response.Items().Slice(), nil
 }
 
 func GetAddOn(client *cmv1.AddOnsClient, id string) (*cmv1.AddOn, error) {
-	addOn, err := client.Addon(id).Get().Send()
+	response, err := client.Addon(id).Get().Send()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf(response.Error().Reason())
 	}
-	return addOn.Body(), nil
+	return response.Body(), nil
 }
 
 type ClusterAddOn struct {
@@ -134,7 +134,7 @@ func GetClusterAddOns(connection *sdk.Connection, clusterID string) ([]*ClusterA
 		Get().
 		Send()
 	if err != nil {
-		return nil, fmt.Errorf("Failed to get current account: %s", err)
+		return nil, fmt.Errorf(acctResponse.Error().Reason())
 	}
 	organization := acctResponse.Body().Organization().ID()
 
@@ -148,7 +148,7 @@ func GetClusterAddOns(connection *sdk.Connection, clusterID string) ([]*ClusterA
 		Size(-1).
 		Send()
 	if err != nil {
-		return nil, fmt.Errorf("Failed to get add-ons: %v", err)
+		return nil, fmt.Errorf(resourceQuotasResponse.Error().Reason())
 	}
 	resourceQuotas := resourceQuotasResponse.Items()
 
@@ -160,7 +160,7 @@ func GetClusterAddOns(connection *sdk.Connection, clusterID string) ([]*ClusterA
 		Size(-1).
 		Send()
 	if err != nil {
-		return nil, fmt.Errorf("Failed to get add-ons: %v", err)
+		return nil, fmt.Errorf(addOnsResponse.Error().Reason())
 	}
 	addOns := addOnsResponse.Items()
 
@@ -173,7 +173,7 @@ func GetClusterAddOns(connection *sdk.Connection, clusterID string) ([]*ClusterA
 		Size(-1).
 		Send()
 	if err != nil {
-		return nil, fmt.Errorf("Failed to get add-on installations for cluster '%s': %v", clusterID, err)
+		return nil, fmt.Errorf(addOnInstallationsResponse.Error().Reason())
 	}
 	addOnInstallations := addOnInstallationsResponse.Items()
 

--- a/pkg/ocm/logs.go
+++ b/pkg/ocm/logs.go
@@ -34,7 +34,7 @@ func GetInstallLogs(client *cmv1.ClustersClient, clusterID string, tail int) (lo
 		Parameter("tail", tail).
 		Send()
 	if err != nil {
-		err = fmt.Errorf("Failed to get logs for cluster '%s': %v", clusterID, err)
+		err = fmt.Errorf(response.Error().Reason())
 		if response.Status() == http.StatusNotFound {
 			err = errors.NotFound.UserErrorf("Failed to get logs for cluster '%s'", clusterID)
 		}
@@ -50,7 +50,7 @@ func GetUninstallLogs(client *cmv1.ClustersClient, clusterID string, tail int) (
 		Parameter("tail", tail).
 		Send()
 	if err != nil {
-		err = fmt.Errorf("Failed to get logs for cluster '%s': %v", clusterID, err)
+		err = fmt.Errorf(response.Error().Reason())
 		if response.Status() == http.StatusNotFound {
 			err = errors.NotFound.UserErrorf("Failed to get logs for cluster '%s'", clusterID)
 		}

--- a/pkg/ocm/machines/machines.go
+++ b/pkg/ocm/machines/machines.go
@@ -17,6 +17,8 @@ limitations under the License.
 package machines
 
 import (
+	"fmt"
+
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 )
 
@@ -33,7 +35,7 @@ func GetMachineTypes(client *cmv1.Client) (machineTypes []*cmv1.MachineType, err
 			Size(size).
 			Send()
 		if err != nil {
-			return
+			return nil, fmt.Errorf(response.Error().Reason())
 		}
 		machineTypes = append(machineTypes, response.Items().Slice()...)
 		if response.Size() < size {

--- a/pkg/ocm/regions/regions.go
+++ b/pkg/ocm/regions/regions.go
@@ -67,7 +67,7 @@ func GetRegions(client *cmv1.Client) (regions []*cmv1.CloudRegion, err error) {
 			Body(awsCredentials).
 			Send()
 		if err != nil {
-			return
+			return nil, fmt.Errorf(response.Error().Reason())
 		}
 		regions = append(regions, response.Items().Slice()...)
 		if response.Size() < size {

--- a/pkg/ocm/versions/versions.go
+++ b/pkg/ocm/versions/versions.go
@@ -41,7 +41,7 @@ func GetVersions(client *cmv1.Client, channelGroup string) (versions []*cmv1.Ver
 			Size(size).
 			Send()
 		if err != nil {
-			return
+			return nil, fmt.Errorf(response.Error().Reason())
 		}
 		versions = append(versions, response.Items().Slice()...)
 		if response.Size() < size {


### PR DESCRIPTION
Now errors only output the relevant message to the user