### PR TITLE
cluster: Default to using paid AMI

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -212,9 +212,10 @@ func init() {
 	flags.BoolVar(
 		&args.usePaidAMI,
 		"use-paid-ami",
-		false,
+		true,
 		"Whether to use the paid AMI from AWS. Requires a valid subscription to the MOA Product.",
 	)
+	flags.MarkDeprecated("use-paid-ami", "please contact support to get access to the paid AMI.")
 }
 
 func run(cmd *cobra.Command, _ []string) {
@@ -496,12 +497,14 @@ func run(cmd *cobra.Command, _ []string) {
 		DryRun:             &args.dryRun,
 	}
 
-	// If the flag is explicitly set, OCM will tell the cluster provisioner
-	// to use the AMI ID from the AWS Marketplace.
-	if cmd.Flags().Changed("use-paid-ami") && args.usePaidAMI {
-		clusterConfig.CustomProperties = map[string]string{
-			properties.UseMarketplaceAMI: "true",
-		}
+	// If the flag is explicitly set to false, OCM will tell the cluster provisioner
+	// to not use the AMI ID from the AWS Marketplace.
+	usePaidAMI := "true"
+	if cmd.Flags().Changed("use-paid-ami") && !args.usePaidAMI {
+		usePaidAMI = "false"
+	}
+	clusterConfig.CustomProperties = map[string]string{
+		properties.UseMarketplaceAMI: usePaidAMI,
 	}
 
 	cluster, err := clusterprovider.CreateCluster(ocmClient.Clusters(), clusterConfig)

--- a/docs/moactl_create_cluster.md
+++ b/docs/moactl_create_cluster.md
@@ -37,7 +37,6 @@ moactl create cluster [flags]
       --private                       Restrict master API endpoint and application routes to direct, private connectivity.
       --watch                         Watch cluster installation logs.
       --dry-run                       Simulate creating the cluster.
-      --use-paid-ami                  Whether to use the paid AMI from AWS. Requires a valid subscription to the MOA Product.
   -h, --help                          help for cluster
 ```
 


### PR DESCRIPTION
Since the goal is to move entirely to using the AWS paid AMI, we default
the flag to true and hide it from end-users. It can still be explicitly
set to 'false' for debugging purposes, and eventually we will deprecate
it.