### PR TITLE
Init test cluster name to less than 15 char

### DIFF
--- a/cmd/initialize/cmd.go
+++ b/cmd/initialize/cmd.go
@@ -225,7 +225,7 @@ func simulateCluster(client *cmv1.ClustersClient, region string) error {
 		region = aws.DefaultRegion
 	}
 	spec := clusterprovider.Spec{
-		Name:             "moactl-init-test",
+		Name:             "moactl-init",
 		Region:           region,
 		CustomProperties: map[string]string{properties.UseMarketplaceAMI: "true"},
 		DryRun:           &dryRun,


### PR DESCRIPTION
Cluster names must be shorter than 15 char.

Prevents the following warning during init:

```
moactl init          
I: Logged in as 'test' on 'https://api.openshift.com'                                                                     
I: Validating AWS credentials...                                                                                                                                                                                                                                                
I: AWS credentials are valid!                                                                                                           
I: Validating SCP policies...                                                                                                                                                                                                                                                   
I: AWS SCP policies ok                                                                                                                  
I: Validating AWS quota...                                                                                                              
I: AWS quota ok                                                                                                                         
I: Ensuring cluster administrator user 'osdCcsAdmin'...                                                                                 
I: Admin user 'osdCcsAdmin' already exists!                                                                                             
I: Validating cluster creation...                                                                                                       
W: Cluster creation failed. If you create a cluster, it should fail with the following error:                                           
Cluster name 'moactl-init-test' is 16 characters long - its length exceeds the maximum length allowed of 15 characters                                                                                                                                                          
I: Verifying whether OpenShift command-line tool is available...                                                                        
I: Current OpenShift Client Version: 4.3.8     
```