### PR TITLE
errors: Fall back to full error message

### DIFF
--- a/pkg/ocm/logs.go
+++ b/pkg/ocm/logs.go
@@ -34,7 +34,7 @@ func GetInstallLogs(client *cmv1.ClustersClient, clusterID string, tail int) (lo
 		Parameter("tail", tail).
 		Send()
 	if err != nil {
-		err = fmt.Errorf(response.Error().Reason())
+		err = handleErr(response.Error(), err)
 		if response.Status() == http.StatusNotFound {
 			err = errors.NotFound.UserErrorf("Failed to get logs for cluster '%s'", clusterID)
 		}
@@ -50,7 +50,7 @@ func GetUninstallLogs(client *cmv1.ClustersClient, clusterID string, tail int) (
 		Parameter("tail", tail).
 		Send()
 	if err != nil {
-		err = fmt.Errorf(response.Error().Reason())
+		err = handleErr(response.Error(), err)
 		if response.Status() == http.StatusNotFound {
 			err = errors.NotFound.UserErrorf("Failed to get logs for cluster '%s'", clusterID)
 		}

--- a/pkg/ocm/machines/machines.go
+++ b/pkg/ocm/machines/machines.go
@@ -17,7 +17,7 @@ limitations under the License.
 package machines
 
 import (
-	"fmt"
+	"errors"
 
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 )
@@ -35,7 +35,11 @@ func GetMachineTypes(client *cmv1.Client) (machineTypes []*cmv1.MachineType, err
 			Size(size).
 			Send()
 		if err != nil {
-			return nil, fmt.Errorf(response.Error().Reason())
+			errMsg := response.Error().Reason()
+			if errMsg == "" {
+				errMsg = err.Error()
+			}
+			return nil, errors.New(errMsg)
 		}
 		machineTypes = append(machineTypes, response.Items().Slice()...)
 		if response.Size() < size {

--- a/pkg/ocm/regions/regions.go
+++ b/pkg/ocm/regions/regions.go
@@ -17,6 +17,7 @@ limitations under the License.
 package regions
 
 import (
+	"errors"
 	"fmt"
 
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
@@ -67,7 +68,11 @@ func GetRegions(client *cmv1.Client) (regions []*cmv1.CloudRegion, err error) {
 			Body(awsCredentials).
 			Send()
 		if err != nil {
-			return nil, fmt.Errorf(response.Error().Reason())
+			errMsg := response.Error().Reason()
+			if errMsg == "" {
+				errMsg = err.Error()
+			}
+			return nil, errors.New(errMsg)
 		}
 		regions = append(regions, response.Items().Slice()...)
 		if response.Size() < size {

--- a/pkg/ocm/versions/versions.go
+++ b/pkg/ocm/versions/versions.go
@@ -17,6 +17,7 @@ limitations under the License.
 package versions
 
 import (
+	"errors"
 	"fmt"
 
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
@@ -41,7 +42,11 @@ func GetVersions(client *cmv1.Client, channelGroup string) (versions []*cmv1.Ver
 			Size(size).
 			Send()
 		if err != nil {
-			return nil, fmt.Errorf(response.Error().Reason())
+			errMsg := response.Error().Reason()
+			if errMsg == "" {
+				errMsg = err.Error()
+			}
+			return nil, errors.New(errMsg)
 		}
 		versions = append(versions, response.Items().Slice()...)
 		if response.Size() < size {


### PR DESCRIPTION
If the user-friendly error Reason is not available, show the OCM
api-friendly error string to avoid empty errors.