### PR TITLE
idp: Always use interactive mode on unset required flags

### DIFF
--- a/cmd/create/idp/cmd.go
+++ b/cmd/create/idp/cmd.go
@@ -336,7 +336,7 @@ func run(cmd *cobra.Command, _ []string) {
 
 	// Grab all the IDP information interactively if necessary
 	idpType := args.idpType
-	if interactive.Enabled() || idpType == "" {
+	if idpType == "" {
 		if idpType == "" {
 			idpType = validIdps[0]
 		}

--- a/cmd/create/idp/github.go
+++ b/cmd/create/idp/github.go
@@ -50,7 +50,7 @@ func buildGithubIdp(cmd *cobra.Command,
 	orgHelp := "You must be an administrator in your organization or create a new one: " +
 		"https://github.com/account/organizations/new"
 
-	if interactive.Enabled() || restrictType == "" {
+	if restrictType == "" && organizations == "" && teams == "" {
 		restrictType, err = interactive.GetOption(interactive.Input{
 			Question: "Restrict to members of",
 			Help: fmt.Sprintf("GitHub authentication lets you use either "+
@@ -64,7 +64,7 @@ func buildGithubIdp(cmd *cobra.Command,
 		}
 	}
 
-	if interactive.Enabled() || (organizations == "" && teams == "") {
+	if organizations == "" && teams == "" {
 		if restrictType == "organizations" {
 			organizations, err = interactive.GetString(interactive.Input{
 				Question: "GitHub organizations",
@@ -94,7 +94,7 @@ func buildGithubIdp(cmd *cobra.Command,
 
 	clientID := args.clientID
 	clientSecret := args.clientSecret
-	if interactive.Enabled() || clientID == "" || clientSecret == "" {
+	if clientID == "" || clientSecret == "" {
 		// Create the full URL to automatically generate the GitHub app info
 		registerURLBase := "https://github.com/settings/applications/new"
 

--- a/cmd/create/idp/gitlab.go
+++ b/cmd/create/idp/gitlab.go
@@ -36,7 +36,7 @@ func buildGitlabIdp(cmd *cobra.Command,
 	clientSecret := args.clientSecret
 	gitlabURL := args.gitlabURL
 
-	if interactive.Enabled() || !cmd.Flags().Changed("host-url") {
+	if !cmd.Flags().Changed("host-url") {
 		gitlabURL, err = interactive.GetString(interactive.Input{
 			Question: "URL",
 			Help:     cmd.Flags().Lookup("host-url").Usage,
@@ -61,7 +61,7 @@ func buildGitlabIdp(cmd *cobra.Command,
 		return idpBuilder, errors.New("GitLab provider URL must not have a fragment")
 	}
 
-	if interactive.Enabled() || clientID == "" || clientSecret == "" {
+	if clientID == "" || clientSecret == "" {
 		instructionsURL := fmt.Sprintf("%s/profile/applications", gitlabURL)
 		consoleURL := cluster.Console().URL()
 		oauthURL := strings.Replace(consoleURL, "console-openshift-console", "oauth-openshift", 1)
@@ -107,7 +107,7 @@ func buildGitlabIdp(cmd *cobra.Command,
 	}
 
 	caPath := args.caPath
-	if interactive.Enabled() {
+	if interactive.Enabled() && cmd.Flags().Changed("host-url") {
 		caPath, err = interactive.GetCert(interactive.Input{
 			Question: "CA file path",
 			Help:     cmd.Flags().Lookup("ca").Usage,

--- a/cmd/create/idp/google.go
+++ b/cmd/create/idp/google.go
@@ -34,7 +34,7 @@ func buildGoogleIdp(cmd *cobra.Command,
 	clientID := args.clientID
 	clientSecret := args.clientSecret
 
-	if interactive.Enabled() || clientID == "" || clientSecret == "" {
+	if clientID == "" || clientSecret == "" {
 		instructionsURL := "https://console.developers.google.com/projectcreate"
 		consoleURL := cluster.Console().URL()
 		oauthURL := strings.Replace(consoleURL, "console-openshift-console", "oauth-openshift", 1)

--- a/cmd/create/idp/ldap.go
+++ b/cmd/create/idp/ldap.go
@@ -35,7 +35,7 @@ func buildLdapIdp(cmd *cobra.Command,
 	ldapURL := args.ldapURL
 	ldapIDs := args.ldapIDs
 
-	if interactive.Enabled() || ldapURL == "" || ldapIDs == "" {
+	if ldapURL == "" || ldapIDs == "" {
 		instructionsURL := "https://docs.openshift.com/dedicated/4/authentication/" +
 			"identity_providers/configuring-ldap-identity-provider.html"
 		err = interactive.PrintHelp(interactive.Help{
@@ -51,7 +51,7 @@ func buildLdapIdp(cmd *cobra.Command,
 		}
 	}
 
-	if interactive.Enabled() || ldapURL == "" {
+	if ldapURL == "" {
 		ldapURL, err = interactive.GetString(interactive.Input{
 			Question: "LDAP URL",
 			Help:     cmd.Flags().Lookup("url").Usage,
@@ -148,7 +148,7 @@ func buildLdapIdp(cmd *cobra.Command,
 		}
 	}
 
-	if interactive.Enabled() || ldapIDs == "" {
+	if ldapIDs == "" {
 		ldapIDs, err = interactive.GetString(interactive.Input{
 			Question: "ID",
 			Help:     cmd.Flags().Lookup("id-attributes").Usage,


### PR DESCRIPTION
For any required attributes, if the user has not set it as a flag in the
CLI, we fallback to displaying the interactive mode for it instead of
failing the request. This also means that for any attribute that the
user has explicitly set through a flag, the tool will not show it even
if the user requested interactive mode.