### PR TITLE
admin: Rename IDP to Cluster-Admin

### DIFF
--- a/cmd/create/admin/cmd.go
+++ b/cmd/create/admin/cmd.go
@@ -31,7 +31,7 @@ import (
 )
 
 const (
-	idpName  = "htpasswd"
+	idpName  = "Cluster-Admin"
 	username = "cluster-admin"
 )
 
@@ -143,12 +143,13 @@ func run(cmd *cobra.Command, _ []string) {
 		reporter.Errorf("Failed to create user '%s' for cluster '%s'", username, clusterKey)
 		os.Exit(1)
 	}
-	_, err = clustersCollection.Cluster(cluster.ID()).
+	userResp, err := clustersCollection.Cluster(cluster.ID()).
 		Groups().Group("cluster-admins").
 		Users().Add().Body(user).
 		Send()
 	if err != nil {
-		reporter.Errorf("Failed to add user '%s' to cluster '%s': %v", username, clusterKey, err)
+		reporter.Errorf("Failed to add user '%s' to cluster '%s': %s",
+			username, clusterKey, userResp.Error().Reason())
 		os.Exit(1)
 	}
 
@@ -171,13 +172,14 @@ func run(cmd *cobra.Command, _ []string) {
 	}
 
 	// Add HTPasswd IDP to cluster:
-	_, err = clustersCollection.Cluster(cluster.ID()).
+	idpResp, err := clustersCollection.Cluster(cluster.ID()).
 		IdentityProviders().
 		Add().
 		Body(idp).
 		Send()
 	if err != nil {
-		reporter.Errorf("Failed to add '%s' identity provider to cluster '%s': %s", idpName, clusterKey, err)
+		reporter.Errorf("Failed to add '%s' identity provider to cluster '%s': %s",
+			idpName, clusterKey, idpResp.Error().Reason())
 		os.Exit(1)
 	}
 

--- a/cmd/describe/admin/cmd.go
+++ b/cmd/describe/admin/cmd.go
@@ -29,7 +29,7 @@ import (
 )
 
 const (
-	idpName = "htpasswd"
+	idpName = "Cluster-Admin"
 	// username = "cluster-admin"
 )
 
@@ -131,7 +131,7 @@ func run(cmd *cobra.Command, _ []string) {
 
 	var idp *cmv1.IdentityProvider
 	for _, item := range idps {
-		if item.Name() == idpName {
+		if ocm.IdentityProviderType(item) == "htpasswd" {
 			idp = item
 		}
 	}

--- a/cmd/list/idp/cmd.go
+++ b/cmd/list/idp/cmd.go
@@ -136,32 +136,13 @@ func run(_ *cobra.Command, _ []string) {
 	writer := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
 	fmt.Fprintf(writer, "NAME\t\tTYPE\t\tAUTH URL\n")
 	for _, idp := range idps {
-		idpType := getType(idp)
+		idpType := ocm.IdentityProviderType(idp)
 		if idpType == "htpasswd" {
 			continue
 		}
-		fmt.Fprintf(writer, "%s\t\t%s\t\t%s\n", idp.Name(), getType(idp), getAuthURL(cluster, idp.Name()))
+		fmt.Fprintf(writer, "%s\t\t%s\t\t%s\n", idp.Name(), idpType, getAuthURL(cluster, idp.Name()))
 	}
 	writer.Flush()
-}
-
-func getType(idp *cmv1.IdentityProvider) string {
-	switch idp.Type() {
-	case "GithubIdentityProvider":
-		return "GitHub"
-	case "GitlabIdentityProvider":
-		return "GitLab"
-	case "GoogleIdentityProvider":
-		return "Google"
-	case "HTPasswdIdentityProvider":
-		return "htpasswd"
-	case "LDAPIdentityProvider":
-		return "LDAP"
-	case "OpenIDIdentityProvider":
-		return "OpenID"
-	}
-
-	return ""
 }
 
 func getAuthURL(cluster *cmv1.Cluster, idpName string) string {

--- a/pkg/ocm/helpers.go
+++ b/pkg/ocm/helpers.go
@@ -88,6 +88,25 @@ func GetIdentityProviders(client *cmv1.ClustersClient, clusterID string) ([]*cmv
 	return response.Items().Slice(), nil
 }
 
+func IdentityProviderType(idp *cmv1.IdentityProvider) string {
+	switch idp.Type() {
+	case "GithubIdentityProvider":
+		return "GitHub"
+	case "GitlabIdentityProvider":
+		return "GitLab"
+	case "GoogleIdentityProvider":
+		return "Google"
+	case "HTPasswdIdentityProvider":
+		return "htpasswd"
+	case "LDAPIdentityProvider":
+		return "LDAP"
+	case "OpenIDIdentityProvider":
+		return "OpenID"
+	}
+
+	return ""
+}
+
 func GetIngresses(client *cmv1.ClustersClient, clusterID string) ([]*cmv1.Ingress, error) {
 	ingressClient := client.Cluster(clusterID).Ingresses()
 	response, err := ingressClient.List().


### PR DESCRIPTION
This makes it more user-friendly when the user opens the console.