### PR TITLE
users: Do not show cluster-admin user

### DIFF
--- a/cmd/list/user/cmd.go
+++ b/cmd/list/user/cmd.go
@@ -128,6 +128,12 @@ func run(_ *cobra.Command, _ []string) {
 			reporter.Errorf("Failed to get cluster-admins for cluster '%s': %v", clusterKey, err)
 			os.Exit(1)
 		}
+		// Remove cluster-admin user
+		for i, user := range clusterAdmins {
+			if user.ID() == "cluster-admin" {
+				clusterAdmins = append(clusterAdmins[:i], clusterAdmins[i+1:]...)
+			}
+		}
 	}
 
 	// Load dedicated-admins for this cluster


### PR DESCRIPTION
When a user runs the 'create admin' command, the service creates
a 'cluster-admin' user for the HTPasswd IdP. This user is generated
internally and not intended to be exposed, so we hide it from the list.