### PR TITLE
aws: Default to free AMI

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,7 @@ Flags:
       --multi-az                      Deploy to multiple data centers.
   -r, --region string                 AWS region where your worker pool will be located. (overrides the AWS_REGION environment variable)
       --version string                Version of OpenShift that will be used to install the cluster, for example "4.3.10"
+      --channel-group string          Channel group is the name of the group where this image belongs, for example "stable" or "fast". (default "stable")
       --compute-machine-type string   Instance type for the compute nodes. Determines the amount of memory and vCPU allocated to each compute node.
       --compute-nodes int             Number of worker nodes to provision per zone. Single zone clusters need at least 2 nodes, multizone clusters need at least 3 nodes. (default 2)
       --machine-cidr ipNet            Block of IP addresses used by OpenShift while installing the cluster, for example "10.0.0.0/16".
@@ -267,8 +268,9 @@ Flags:
       --pod-cidr ipNet                Block of IP addresses from which Pod IP addresses are allocated, for example "10.128.0.0/14".
       --host-prefix int               Subnet prefix length to assign to each individual node. For example, if host prefix is set to "23", then each node is assigned a /23 subnet out of the given CIDR.
       --private                       Restrict master API endpoint and application routes to direct, private connectivity.
+      --disable-scp-checks            Indicates if cloud permission checks are disabled when attempting installation of the cluster.
       --watch                         Watch cluster installation logs.
-      --use-paid-ami                  Whether to use the paid AMI from AWS. Requires a valid subscription to the MOA Product.
+      --dry-run                       Simulate creating the cluster.
   -h, --help                          help for cluster
 
 Global Flags:

--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -222,10 +222,10 @@ func init() {
 	flags.BoolVar(
 		&args.usePaidAMI,
 		"use-paid-ami",
-		true,
+		false,
 		"Whether to use the paid AMI from AWS. Requires a valid subscription to the MOA Product.",
 	)
-	flags.MarkDeprecated("use-paid-ami", "please contact support to get access to the paid AMI.")
+	flags.MarkHidden("use-paid-ami")
 }
 
 func run(cmd *cobra.Command, _ []string) {
@@ -509,14 +509,12 @@ func run(cmd *cobra.Command, _ []string) {
 		DisableSCPChecks:   &args.disableSCPChecks,
 	}
 
-	// If the flag is explicitly set to false, OCM will tell the cluster provisioner
-	// to not use the AMI ID from the AWS Marketplace.
-	usePaidAMI := "true"
-	if cmd.Flags().Changed("use-paid-ami") && !args.usePaidAMI {
-		usePaidAMI = "false"
-	}
-	clusterConfig.CustomProperties = map[string]string{
-		properties.UseMarketplaceAMI: usePaidAMI,
+	// If the flag is explicitly set to true, OCM will tell the cluster provisioner
+	// to use the AMI ID from the AWS Marketplace.
+	if cmd.Flags().Changed("use-paid-ami") && args.usePaidAMI {
+		clusterConfig.CustomProperties = map[string]string{
+			properties.UseMarketplaceAMI: "true",
+		}
 	}
 
 	cluster, err := clusterprovider.CreateCluster(ocmClient.Clusters(), clusterConfig)

--- a/cmd/initialize/cmd.go
+++ b/cmd/initialize/cmd.go
@@ -32,7 +32,6 @@ import (
 	"github.com/openshift/moactl/pkg/logging"
 	"github.com/openshift/moactl/pkg/ocm"
 	"github.com/openshift/moactl/pkg/ocm/config"
-	"github.com/openshift/moactl/pkg/ocm/properties"
 	rprtr "github.com/openshift/moactl/pkg/reporter"
 )
 
@@ -225,10 +224,9 @@ func simulateCluster(client *cmv1.ClustersClient, region string) error {
 		region = aws.DefaultRegion
 	}
 	spec := clusterprovider.Spec{
-		Name:             "moactl-init",
-		Region:           region,
-		CustomProperties: map[string]string{properties.UseMarketplaceAMI: "true"},
-		DryRun:           &dryRun,
+		Name:   "moactl-init",
+		Region: region,
+		DryRun: &dryRun,
 	}
 
 	_, err := clusterprovider.CreateCluster(client, spec)


### PR DESCRIPTION
@acathrow - For now, I'm leaving the `--use-paid-ami` as a hidden/secret flag until we move the selection to Unleash.