### PR TITLE
Adding Orange team members to OWNERS file

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -4,11 +4,15 @@ reviewers:
 - igoihman
 - jeremyeder 
 - NautiluX 
+- boranx
+- georgettica
+- sulmer
 approvers:
 - jharrington22
 - vkareh 
 - igoihman
 - jeremyeder 
+- NautiluX
 maintainers:
 - jharrington22
 - vkareh 

--- a/OWNERS
+++ b/OWNERS
@@ -6,7 +6,7 @@ reviewers:
 - NautiluX 
 - boranx
 - georgettica
-- sulmer
+- sulmer-redhat
 approvers:
 - jharrington22
 - vkareh 


### PR DESCRIPTION
Allow contributing members to review and approve PRs, to speed up
review process in moactl