### PR TITLE
Release v0.1.0

### DIFF
--- a/CHANGES.adoc
+++ b/CHANGES.adoc
@@ -3,6 +3,14 @@
 This document describes the relevant changes between releases of the `moactl`
 command line tool.
 
+== 0.1.0 Oct 30 2020
+
+- admin: Rename IDP to Cluster-Admin
+- ingress: Enable interactive mode
+- Red Hat OpenShift Service on AWS
+- Remove shard info from describe cluster
+- roles: Update flow to use grant and revoke
+
 == 0.0.16 Oct 22 2020
 
 - Add tags to template, not working

--- a/pkg/info/info.go
+++ b/pkg/info/info.go
@@ -18,4 +18,4 @@ limitations under the License.
 
 package info
 
-const Version = "0.0.16"
+const Version = "0.1.0"


### PR DESCRIPTION
- admin: Rename IDP to Cluster-Admin
- ingress: Enable interactive mode
- Red Hat OpenShift Service on AWS
- Remove shard info from describe cluster
- roles: Update flow to use grant and revoke