### PR TITLE
refactor(init): verify permissions for osdccsadmin using ValidateSCP

### DIFF
--- a/cmd/initialize/cmd.go
+++ b/cmd/initialize/cmd.go
@@ -205,6 +205,16 @@ func run(cmd *cobra.Command, argv []string) {
 		reporter.Infof("Admin user '%s' already exists!", aws.AdminUserName)
 	}
 
+	// Check if osdCcsAdmin has right permissions
+	reporter.Infof("Validating SCP policies for '%s'...", aws.AdminUserName)
+	target := aws.AdminUserName
+	isValid, err := client.ValidateSCP(&target)
+	if !isValid {
+		reporter.Errorf("Failed to verify permissions for user '%s': %v", target, err)
+		os.Exit(1)
+	}
+	reporter.Infof("AWS SCP policies ok")
+
 	// Check whether the user can create a basic cluster
 	reporter.Infof("Validating cluster creation...")
 	err = simulateCluster(clustersCollection, args.region)

--- a/cmd/verify/permissions/cmd.go
+++ b/cmd/verify/permissions/cmd.go
@@ -61,7 +61,7 @@ func run(cmd *cobra.Command, argv []string) {
 	}
 
 	reporter.Infof("Validating SCP policies...")
-	ok, err := client.ValidateSCP()
+	ok, err := client.ValidateSCP(nil)
 	if err != nil {
 		reporter.Errorf("Unable to validate SCP policies")
 		if strings.Contains(err.Error(), "Throttling: Rate exceeded") {


### PR DESCRIPTION
Fixes: [OSD-4708](https://issues.redhat.com/browse/OSD-4708)

Note that ValidateSCP is not testable because of calling private functions continuously. As well as that can be handled in that PR, though I'd prefer to work on it at another PR 
