### PR TITLE
Remove paid AMI flag and finalize ROSA transition

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ In this step you log in to your Red Hat account using `rosa`, and then initializ
 
 If you do not already have a Red Hat account, [create one here](https://cloud.redhat.com/). Be sure to accept the required terms and conditions. Then, check your email for a verification link.  
 
-After creating your Red Hat account, follow this link to [get an offline access token](https://cloud.redhat.com/openshift/token/moa
+After creating your Red Hat account, follow this link to [get an offline access token](https://cloud.redhat.com/openshift/token/rosa
 ).
 
 Run the following command to log in to your Red Hat account with rosa. Replace &lt;my-offline-access-token&gt; with your token:

--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -39,7 +39,6 @@ import (
 	"github.com/openshift/moactl/pkg/logging"
 	"github.com/openshift/moactl/pkg/ocm"
 	"github.com/openshift/moactl/pkg/ocm/machines"
-	"github.com/openshift/moactl/pkg/ocm/properties"
 	"github.com/openshift/moactl/pkg/ocm/regions"
 	"github.com/openshift/moactl/pkg/ocm/versions"
 	rprtr "github.com/openshift/moactl/pkg/reporter"
@@ -51,9 +50,6 @@ var args struct {
 
 	// Simulate creating a cluster
 	dryRun bool
-
-	// Whether to use the AMI image override from the AWS marketplace
-	usePaidAMI bool
 
 	// Disable SCP checks in the installer
 	disableSCPChecks bool
@@ -234,15 +230,6 @@ func init() {
 			"Subnets are comma separated, for example: --subnet-ids=subnet-1,subnet-2."+
 			"Leave empty for installer provisioned subnet IDs.",
 	)
-
-	flags.BoolVar(
-		&args.usePaidAMI,
-		"use-paid-ami",
-		false,
-		"Whether to use the paid AMI from AWS. Requires a valid subscription to the MOA Product.",
-	)
-
-	flags.MarkHidden("use-paid-ami")
 }
 
 func run(cmd *cobra.Command, _ []string) {
@@ -618,14 +605,6 @@ func run(cmd *cobra.Command, _ []string) {
 		DisableSCPChecks:   &args.disableSCPChecks,
 		AvailabilityZones:  availabilityZones,
 		SubnetIds:          subnetIDs,
-	}
-
-	// If the flag is explicitly set to true, OCM will tell the cluster provisioner
-	// to use the AMI ID from the AWS Marketplace.
-	if cmd.Flags().Changed("use-paid-ami") && args.usePaidAMI {
-		clusterConfig.CustomProperties = map[string]string{
-			properties.UseMarketplaceAMI: "true",
-		}
 	}
 
 	reporter.Infof("Creating cluster '%s'", clusterName)

--- a/cmd/login/cmd.go
+++ b/cmd/login/cmd.go
@@ -32,7 +32,7 @@ import (
 )
 
 // #nosec G101
-const uiTokenPage = "https://cloud.redhat.com/openshift/token/moa"
+const uiTokenPage = "https://cloud.redhat.com/openshift/token/rosa"
 
 var args struct {
 	tokenURL     string
@@ -52,8 +52,9 @@ var Cmd = &cobra.Command{
 		"The application looks for the token in the following order, stopping when it finds it:\n"+
 		"\t1. Command-line flags\n"+
 		"\t2. Environment variable (ROSA_TOKEN)\n"+
-		"\t3. Configuration file\n"+
-		"\t4. Command-line prompt\n", uiTokenPage),
+		"\t3. Environment variable (OCM_TOKEN)\n"+
+		"\t4. Configuration file\n"+
+		"\t5. Command-line prompt\n", uiTokenPage),
 	Example: `  # Login to the OpenShift staging API with an existing token
   rosa login --env staging --token=$OFFLINE_ACCESS_TOKEN
 
@@ -144,9 +145,8 @@ func run(cmd *cobra.Command, argv []string) {
 	// Verify environment variables:
 	if !haveReqs {
 		token = os.Getenv("ROSA_TOKEN")
-		// TODO: Remove in a future release to deprecate MOA
 		if token == "" {
-			token = os.Getenv("MOA_TOKEN")
+			token = os.Getenv("OCM_TOKEN")
 		}
 		haveReqs = token != ""
 	}

--- a/docs/rosa_login.md
+++ b/docs/rosa_login.md
@@ -5,13 +5,14 @@ Log in to your Red Hat account
 ### Synopsis
 
 Log in to your Red Hat account, saving the credentials to the configuration file.
-The supported mechanism is by using a token, which can be obtained at: https://cloud.redhat.com/openshift/token/moa
+The supported mechanism is by using a token, which can be obtained at: https://cloud.redhat.com/openshift/token/rosa
 
 The application looks for the token in the following order, stopping when it finds it:
 	1. Command-line flags
 	2. Environment variable (ROSA_TOKEN)
-	3. Configuration file
-	4. Command-line prompt
+	3. Environment variable (OCM_TOKEN)
+	4. Configuration file
+	5. Command-line prompt
 
 
 ```

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -334,9 +334,8 @@ func createClusterSpec(config Spec, awsClient aws.Client) (*cmv1.Cluster, error)
 		DisplayName(config.Name).
 		MultiAZ(config.MultiAZ).
 		Product(
-			// TODO: Change to "rosa" once OCM is updated
 			cmv1.NewProduct().
-				ID("moa"),
+				ID("rosa"),
 		).
 		Region(
 			cmv1.NewCloudRegion().

--- a/pkg/ocm/properties/properties.go
+++ b/pkg/ocm/properties/properties.go
@@ -20,14 +20,10 @@ limitations under the License.
 package properties
 
 // Prefix used by all the property names:
-// TODO: Change to "rosa_" once OCM is updated
-const prefix = "moa_"
+const prefix = "rosa_"
 
 // CreatorARN is the name of the label that will contain the ARN of the user that created the
 // cluster:
 const CreatorARN = prefix + "creator_arn"
 
 const CLIVersion = prefix + "cli_version"
-
-// UseMarketplaceAMI tells the cluster provisioner whether to use the AMRO AMI ID from the AWS marketplace.
-const UseMarketplaceAMI = prefix + "use_marketplace_ami"

--- a/pkg/ocm/versions/versions.go
+++ b/pkg/ocm/versions/versions.go
@@ -29,8 +29,7 @@ func GetVersions(client *cmv1.Client, channelGroup string) (versions []*cmv1.Ver
 	collection := client.Versions()
 	page := 1
 	size := 100
-	// TODO: Change to rosa_enabled once OCM is updated
-	filter := "enabled = 'true' AND moa_enabled = 'true'"
+	filter := "enabled = 'true' AND rosa_enabled = 'true'"
 	if channelGroup != "" {
 		filter = fmt.Sprintf("%s AND channel_group = '%s'", filter, channelGroup)
 	}


### PR DESCRIPTION
Since we're now moving paid AMIs to be a feature flag in Unleash, we
remove the attribute from here and let OCM make the decision based on
the user's organization.

We also finalize the transition from MOA to ROSA, since all dependencies
are now deployed.