### PR TITLE
machinepool: Allow managing 'default' machinepool

### DIFF
--- a/cmd/dlt/machinepool/cmd.go
+++ b/cmd/dlt/machinepool/cmd.go
@@ -91,6 +91,11 @@ func run(_ *cobra.Command, argv []string) {
 		os.Exit(1)
 	}
 
+	if machinePoolID == "default" {
+		reporter.Errorf("Machine pool '%s' cannot be deleted from cluster '%s'", machinePoolID, clusterKey)
+		os.Exit(1)
+	}
+
 	// Create the AWS client:
 	awsClient, err := aws.NewClient().
 		Logger(logger).

--- a/cmd/list/machinepool/cmd.go
+++ b/cmd/list/machinepool/cmd.go
@@ -128,37 +128,37 @@ func run(_ *cobra.Command, _ []string) {
 		os.Exit(1)
 	}
 
-	if len(machinePools) == 0 {
-		reporter.Infof("There are no machine pools configured for cluster '%s'", clusterKey)
-		os.Exit(0)
-	}
-
 	// Create the writer that will be used to print the tabulated results:
 	writer := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
 
 	fmt.Fprintf(writer, "ID\tREPLICAS\tINSTANCE TYPE\tLABELS\t\tAVAILABILITY ZONES\n")
+	fmt.Fprintf(writer, "%s\t%d\t%s\t%s\t\t%s\n",
+		"default",
+		cluster.Nodes().Compute(),
+		cluster.Nodes().ComputeMachineType().ID(),
+		printLabels(cluster.Nodes().ComputeLabels()),
+		printAZ(cluster.Nodes().AvailabilityZones()),
+	)
 	for _, machinePool := range machinePools {
 		fmt.Fprintf(writer, "%s\t%d\t%s\t%s\t\t%s\n",
 			machinePool.ID(),
 			machinePool.Replicas(),
 			machinePool.InstanceType(),
-			printLabels(machinePool),
-			printAZ(machinePool),
+			printLabels(machinePool.Labels()),
+			printAZ(machinePool.AvailabilityZones()),
 		)
 	}
 	writer.Flush()
 }
 
-func printAZ(machinePool *cmv1.MachinePool) string {
-	az := machinePool.AvailabilityZones()
+func printAZ(az []string) string {
 	if len(az) == 0 {
 		return ""
 	}
 	return strings.Join(az, ", ")
 }
 
-func printLabels(machinePool *cmv1.MachinePool) string {
-	labels := machinePool.Labels()
+func printLabels(labels map[string]string) string {
 	if len(labels) == 0 {
 		return ""
 	}

--- a/docs/rosa_edit_cluster.md
+++ b/docs/rosa_edit_cluster.md
@@ -27,7 +27,6 @@ rosa edit cluster [flags]
 
 ```
   -c, --cluster string          Name or ID of the cluster to edit.
-      --compute-nodes int       Number of worker nodes to provision per zone. Single zone clusters need at least 2 nodes, while multizone clusters need at least 3 nodes (1 per zone) for resiliency.
       --private                 Restrict master API endpoint to direct, private connectivity.
       --enable-cluster-admins   Enable the cluster-admins role for your cluster.
   -h, --help                    help for cluster


### PR DESCRIPTION
Since we have the machinery for managing machinepools, we can scale the
cluster itself using this resource and so remove the scaling options on
'edit cluster'.