### PR TITLE
Release v0.1.1

### DIFF
--- a/CHANGES.adoc
+++ b/CHANGES.adoc
@@ -3,6 +3,15 @@
 This document describes the relevant changes between releases of the `moactl`
 command line tool.
 
+== 0.1.1 Nov 5 2020
+
+- refactor(init): verify permissions for osdccsadmin using ValidateSCP
+- machinepools: Support full CRUD operations for machine pools
+- Added validation for name
+- Added Details Page Link
+- machinepool: Allow managing 'default' machinepool
+- Rotate osdCcsAdmin credentails on creation of each cluster (#118)
+
 == 0.1.0 Oct 30 2020
 
 - admin: Rename IDP to Cluster-Admin

--- a/pkg/info/info.go
+++ b/pkg/info/info.go
@@ -18,4 +18,4 @@ limitations under the License.
 
 package info
 
-const Version = "0.1.0"
+const Version = "0.1.1"


### PR DESCRIPTION
- refactor(init): verify permissions for osdccsadmin using ValidateSCP
- machinepools: Support full CRUD operations for machine pools
- Added validation for name
- Added Details Page Link
- machinepool: Allow managing 'default' machinepool
- Rotate osdCcsAdmin credentails on creation of each cluster (#118)