### PR TITLE
Return clear error message when no version is found

### DIFF
--- a/cmd/create/cluster/cmd.go
+++ b/cmd/create/cluster/cmd.go
@@ -655,6 +655,11 @@ func getVersionList(client *cmv1.Client, channelGroup string) (versionList []str
 		versionList = append(versionList, strings.Replace(v.ID(), "openshift-v", "", 1))
 	}
 
+	if len(versionList) == 0 {
+		err = fmt.Errorf("Could not find versions for the provided channel-group: '%s'", channelGroup)
+		return
+	}
+
 	return
 }
 


### PR DESCRIPTION
When a user provides some random channel-group (or one that she isn't authorized to see) she receives the following error:
```
[nshneor@localhost moactl]$ ./rosa create cluster --channel-group=foo
I: Enabling interactive mode
? Cluster name: foo
? Multiple availability zones (optional): No
? AWS region: us-west-1
E: Expected a valid OpenShift version: please provide options to select from
```

This patch fixes this behavior by returning a more clear error message for this scenario:
```
...
E: Failed to find versions for the provided channel-group: 'foo'.
```

JIRA: https://issues.redhat.com/browse/SDA-2968

cc: @vkareh @igoihman 