### PR TITLE
upgrades: Allow scheduling, listing, canceling cluster upgrades

### DIFF
--- a/cmd/dlt/cmd.go
+++ b/cmd/dlt/cmd.go
@@ -24,6 +24,7 @@ import (
 	"github.com/openshift/moactl/cmd/dlt/idp"
 	"github.com/openshift/moactl/cmd/dlt/ingress"
 	"github.com/openshift/moactl/cmd/dlt/machinepool"
+	"github.com/openshift/moactl/cmd/dlt/upgrade"
 	"github.com/openshift/moactl/pkg/confirm"
 )
 
@@ -43,4 +44,5 @@ func init() {
 	Cmd.AddCommand(idp.Cmd)
 	Cmd.AddCommand(ingress.Cmd)
 	Cmd.AddCommand(machinepool.Cmd)
+	Cmd.AddCommand(upgrade.Cmd)
 }

--- a/cmd/dlt/upgrade/cmd.go
+++ b/cmd/dlt/upgrade/cmd.go
@@ -1,0 +1,148 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package upgrade
+
+import (
+	"os"
+
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	"github.com/spf13/cobra"
+
+	"github.com/openshift/moactl/pkg/aws"
+	c "github.com/openshift/moactl/pkg/cluster"
+	"github.com/openshift/moactl/pkg/confirm"
+	"github.com/openshift/moactl/pkg/logging"
+	"github.com/openshift/moactl/pkg/ocm"
+	"github.com/openshift/moactl/pkg/ocm/upgrades"
+	rprtr "github.com/openshift/moactl/pkg/reporter"
+)
+
+var args struct {
+	clusterKey string
+}
+
+var Cmd = &cobra.Command{
+	Use:     "upgrade",
+	Aliases: []string{"upgrades"},
+	Short:   "Cancel cluster upgrade",
+	Long:    "Cancel scheduled cluster upgrade",
+	Run:     run,
+}
+
+func init() {
+	flags := Cmd.Flags()
+	flags.SortFlags = false
+
+	flags.StringVarP(
+		&args.clusterKey,
+		"cluster",
+		"c",
+		"",
+		"Name or ID of the cluster to cancel the upgrade for (required)",
+	)
+	Cmd.MarkFlagRequired("cluster")
+}
+
+func run(cmd *cobra.Command, _ []string) {
+	reporter := rprtr.CreateReporterOrExit()
+	logger := logging.CreateLoggerOrExit(reporter)
+
+	// Check that the cluster key (name, identifier or external identifier) given by the user
+	// is reasonably safe so that there is no risk of SQL injection:
+	clusterKey := args.clusterKey
+	if !c.IsValidClusterKey(clusterKey) {
+		reporter.Errorf(
+			"Cluster name, identifier or external identifier '%s' isn't valid: it "+
+				"must contain only letters, digits, dashes and underscores",
+			clusterKey,
+		)
+		os.Exit(1)
+	}
+
+	// Create the AWS client:
+	var err error
+	awsClient, err := aws.NewClient().
+		Logger(logger).
+		Build()
+	if err != nil {
+		reporter.Errorf("Failed to create AWS client: %v", err)
+		os.Exit(1)
+	}
+
+	awsCreator, err := awsClient.GetCreator()
+	if err != nil {
+		reporter.Errorf("Failed to get AWS creator: %v", err)
+		os.Exit(1)
+	}
+
+	// Create the client for the OCM API:
+	ocmConnection, err := ocm.NewConnection().
+		Logger(logger).
+		Build()
+	if err != nil {
+		reporter.Errorf("Failed to create OCM connection: %v", err)
+		os.Exit(1)
+	}
+	defer func() {
+		err = ocmConnection.Close()
+		if err != nil {
+			reporter.Errorf("Failed to close OCM connection: %v", err)
+		}
+	}()
+
+	// Get the client for the OCM collection of clusters:
+	ocmClient := ocmConnection.ClustersMgmt().V1()
+
+	// Try to find the cluster:
+	reporter.Debugf("Loading cluster '%s'", clusterKey)
+	cluster, err := ocm.GetCluster(ocmClient.Clusters(), clusterKey, awsCreator.ARN)
+	if err != nil {
+		reporter.Errorf("Failed to get cluster '%s': %v", clusterKey, err)
+		os.Exit(1)
+	}
+
+	if cluster.State() != cmv1.ClusterStateReady {
+		reporter.Errorf("Cluster '%s' is not yet ready", clusterKey)
+		os.Exit(1)
+	}
+
+	scheduledUpgrade, err := upgrades.GetScheduledUpgrade(ocmClient, cluster.ID())
+	if err != nil {
+		reporter.Errorf("Failed to get scheduled upgrades for cluster '%s': %v", clusterKey, err)
+		os.Exit(1)
+	}
+	if scheduledUpgrade == nil {
+		reporter.Warnf("There are no scheduled upgrades on cluster '%s'", clusterKey)
+		os.Exit(0)
+	}
+
+	if confirm.Confirm("cancel scheduled upgrade on cluster %s", clusterKey) {
+		reporter.Debugf("Deleting scheduled upgrade for cluster '%s'", clusterKey)
+		canceled, err := upgrades.CancelUpgrade(ocmClient, cluster.ID())
+		if err != nil {
+			reporter.Errorf("Failed to cancel scheduled upgrade on cluster '%s': %v", clusterKey, err)
+			os.Exit(1)
+		}
+
+		if !canceled {
+			reporter.Warnf("There were no scheduled upgrades on cluster '%s'", clusterKey)
+			os.Exit(0)
+		}
+
+		reporter.Infof("Successfully canceled scheduled upgrade on cluster '%s'", clusterKey)
+	}
+}

--- a/cmd/list/cmd.go
+++ b/cmd/list/cmd.go
@@ -25,6 +25,7 @@ import (
 	"github.com/openshift/moactl/cmd/list/ingress"
 	"github.com/openshift/moactl/cmd/list/machinepool"
 	"github.com/openshift/moactl/cmd/list/region"
+	"github.com/openshift/moactl/cmd/list/upgrade"
 	"github.com/openshift/moactl/cmd/list/user"
 	"github.com/openshift/moactl/cmd/list/version"
 )
@@ -42,6 +43,7 @@ func init() {
 	Cmd.AddCommand(ingress.Cmd)
 	Cmd.AddCommand(machinepool.Cmd)
 	Cmd.AddCommand(region.Cmd)
+	Cmd.AddCommand(upgrade.Cmd)
 	Cmd.AddCommand(user.Cmd)
 	Cmd.AddCommand(version.Cmd)
 }

--- a/cmd/list/upgrade/cmd.go
+++ b/cmd/list/upgrade/cmd.go
@@ -1,0 +1,175 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package upgrade
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"text/tabwriter"
+
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	"github.com/spf13/cobra"
+
+	"github.com/openshift/moactl/pkg/aws"
+	"github.com/openshift/moactl/pkg/logging"
+	"github.com/openshift/moactl/pkg/ocm"
+	"github.com/openshift/moactl/pkg/ocm/upgrades"
+	"github.com/openshift/moactl/pkg/ocm/versions"
+	rprtr "github.com/openshift/moactl/pkg/reporter"
+)
+
+var args struct {
+	clusterKey string
+}
+
+var Cmd = &cobra.Command{
+	Use:     "upgrades",
+	Aliases: []string{"upgrade"},
+	Short:   "List available cluster upgrades",
+	Long:    "List available and scheduled cluster version upgrades",
+	Run:     run,
+}
+
+func init() {
+	flags := Cmd.Flags()
+
+	flags.StringVarP(
+		&args.clusterKey,
+		"cluster",
+		"c",
+		"",
+		"Name or ID of the cluster to list the upgrades of (required).",
+	)
+	Cmd.MarkFlagRequired("cluster")
+}
+
+func run(_ *cobra.Command, _ []string) {
+	reporter := rprtr.CreateReporterOrExit()
+	logger := logging.CreateLoggerOrExit(reporter)
+
+	// Check that the cluster key (name, identifier or external identifier) given by the user
+	// is reasonably safe so that there is no risk of SQL injection:
+	clusterKey := args.clusterKey
+	if !ocm.IsValidClusterKey(clusterKey) {
+		reporter.Errorf(
+			"Cluster name, identifier or external identifier '%s' isn't valid: it "+
+				"must contain only letters, digits, dashes and underscores",
+			clusterKey,
+		)
+		os.Exit(1)
+	}
+
+	// Create the client for the OCM API:
+	ocmConnection, err := ocm.NewConnection().
+		Logger(logger).
+		Build()
+	if err != nil {
+		reporter.Errorf("Failed to create OCM connection: %v", err)
+		os.Exit(1)
+	}
+	defer func() {
+		err = ocmConnection.Close()
+		if err != nil {
+			reporter.Errorf("Failed to close OCM connection: %v", err)
+		}
+	}()
+	ocmClient := ocmConnection.ClustersMgmt().V1()
+
+	// Create the AWS client:
+	awsClient, err := aws.NewClient().
+		Logger(logger).
+		Build()
+	if err != nil {
+		reporter.Errorf("Failed to create AWS client: %v", err)
+		os.Exit(1)
+	}
+
+	awsCreator, err := awsClient.GetCreator()
+	if err != nil {
+		reporter.Errorf("Failed to get AWS creator: %v", err)
+		os.Exit(1)
+	}
+
+	// Try to find the cluster:
+	reporter.Debugf("Loading cluster '%s'", clusterKey)
+	cluster, err := ocm.GetCluster(ocmClient.Clusters(), clusterKey, awsCreator.ARN)
+	if err != nil {
+		reporter.Errorf("Failed to get cluster '%s': %v", clusterKey, err)
+		os.Exit(1)
+	}
+
+	if cluster.State() != cmv1.ClusterStateReady {
+		reporter.Errorf("Cluster '%s' is not yet ready", clusterKey)
+		os.Exit(1)
+	}
+
+	// Load available upgrades for this cluster
+	reporter.Debugf("Loading available upgrades for cluster '%s'", clusterKey)
+	availableUpgrades, err := versions.GetAvailableUpgrades(ocmClient, versions.GetVersionID(cluster))
+	if err != nil {
+		reporter.Errorf("Failed to get available upgrades for cluster '%s': %v", clusterKey, err)
+		os.Exit(1)
+	}
+
+	if len(availableUpgrades) == 0 {
+		reporter.Infof("There are no available upgrades for cluster '%s'", clusterKey)
+		os.Exit(0)
+	}
+
+	latestRev := latestInCurrentMinor(versions.GetVersionID(cluster), availableUpgrades)
+
+	reporter.Debugf("Loading scheduled upgrades for cluster '%s'", clusterKey)
+	scheduledUpgrade, err := upgrades.GetScheduledUpgrade(ocmClient, cluster.ID())
+	if err != nil {
+		reporter.Errorf("Failed to get scheduled upgrades for cluster '%s': %v", clusterKey, err)
+		os.Exit(1)
+	}
+
+	// Create the writer that will be used to print the tabulated results:
+	writer := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintf(writer, "VERSION\tNOTES\n")
+	for i, availableUpgrade := range availableUpgrades {
+		notes := ""
+		if notes == "" && (i == 0 || availableUpgrade == latestRev) {
+			notes = "recommended"
+		}
+		if availableUpgrade == scheduledUpgrade.Version() {
+			notes = fmt.Sprintf("scheduled for %s", scheduledUpgrade.NextRun().Format("2006-01-02 15:04 MST"))
+		}
+		fmt.Fprintf(writer, "%s\t%s\n", availableUpgrade, notes)
+	}
+	writer.Flush()
+}
+
+func latestInCurrentMinor(current string, versions []string) string {
+	currentParts := strings.Split(current, ".")
+	currentRev := currentParts[2]
+	latestVersion := current
+	latestRev := currentRev
+	for _, version := range versions {
+		versionParts := strings.Split(version, ".")
+		if currentParts[1] != versionParts[1] {
+			continue
+		}
+		if versionParts[2] > latestRev {
+			latestRev = versionParts[2]
+			latestVersion = version
+		}
+	}
+	return latestVersion
+}

--- a/cmd/rosa/main.go
+++ b/cmd/rosa/main.go
@@ -38,6 +38,7 @@ import (
 	"github.com/openshift/moactl/cmd/logout"
 	"github.com/openshift/moactl/cmd/logs"
 	"github.com/openshift/moactl/cmd/revoke"
+	"github.com/openshift/moactl/cmd/upgrade"
 	"github.com/openshift/moactl/cmd/verify"
 	"github.com/openshift/moactl/cmd/version"
 	"github.com/openshift/moactl/cmd/whoami"
@@ -76,6 +77,7 @@ func init() {
 	root.AddCommand(logout.Cmd)
 	root.AddCommand(logs.Cmd)
 	root.AddCommand(revoke.Cmd)
+	root.AddCommand(upgrade.Cmd)
 	root.AddCommand(verify.Cmd)
 	root.AddCommand(version.Cmd)
 	root.AddCommand(whoami.Cmd)

--- a/cmd/upgrade/cluster/cmd.go
+++ b/cmd/upgrade/cluster/cmd.go
@@ -1,0 +1,375 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cluster
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	"github.com/spf13/cobra"
+
+	"github.com/openshift/moactl/pkg/aws"
+	c "github.com/openshift/moactl/pkg/cluster"
+	"github.com/openshift/moactl/pkg/interactive"
+	"github.com/openshift/moactl/pkg/logging"
+	"github.com/openshift/moactl/pkg/ocm"
+	"github.com/openshift/moactl/pkg/ocm/upgrades"
+	"github.com/openshift/moactl/pkg/ocm/versions"
+	rprtr "github.com/openshift/moactl/pkg/reporter"
+)
+
+var args struct {
+	clusterKey           string
+	version              string
+	scheduleDate         string
+	scheduleTime         string
+	nodeDrainGracePeriod string
+}
+
+var Cmd = &cobra.Command{
+	Use:   "cluster",
+	Short: "Upgrade cluster",
+	Long:  "Upgrade cluster to a new available version",
+	Example: `  # Interactively schedule an upgrade on the cluster named "mycluster"
+  rosa upgrade cluster --cluster=mycluster --interactive
+
+  # Schedule a cluster upgrade within the hour
+  rosa upgade cluster -c mycluster --version 4.5.20`,
+	Run: run,
+}
+
+func init() {
+	flags := Cmd.Flags()
+	flags.SortFlags = false
+
+	flags.StringVarP(
+		&args.clusterKey,
+		"cluster",
+		"c",
+		"",
+		"Name or ID of the cluster to schedule the upgrade for (required)",
+	)
+	Cmd.MarkFlagRequired("cluster")
+
+	flags.StringVar(
+		&args.version,
+		"version",
+		"",
+		"Version of OpenShift that the cluster will be upgraded to",
+	)
+
+	flags.StringVar(
+		&args.scheduleDate,
+		"schedule-date",
+		"",
+		"Next date the upgrade should run at the specified time. Format should be 'yyyy-mm-dd'",
+	)
+
+	flags.StringVar(
+		&args.scheduleTime,
+		"schedule-time",
+		"",
+		"Next time the upgrade should run on the specified date. Format should be 'HH:mm'",
+	)
+
+	flags.StringVar(
+		&args.nodeDrainGracePeriod,
+		"node-drain-grace-period",
+		"1 hour",
+		"You may set a grace period for how long Pod Disruption Budget-protected workloads will be "+
+			"respected during upgrades.\nAfter this grace period, any workloads protected by Pod Disruption "+
+			"Budgets that have not been successfully drained from a node will be forcibly evicted",
+	)
+}
+
+func run(cmd *cobra.Command, _ []string) {
+	reporter := rprtr.CreateReporterOrExit()
+	logger := logging.CreateLoggerOrExit(reporter)
+
+	// Check that the cluster key (name, identifier or external identifier) given by the user
+	// is reasonably safe so that there is no risk of SQL injection:
+	clusterKey := args.clusterKey
+	if !c.IsValidClusterKey(clusterKey) {
+		reporter.Errorf(
+			"Cluster name, identifier or external identifier '%s' isn't valid: it "+
+				"must contain only letters, digits, dashes and underscores",
+			clusterKey,
+		)
+		os.Exit(1)
+	}
+
+	// Create the AWS client:
+	var err error
+	awsClient, err := aws.NewClient().
+		Logger(logger).
+		Build()
+	if err != nil {
+		reporter.Errorf("Failed to create AWS client: %v", err)
+		os.Exit(1)
+	}
+
+	awsCreator, err := awsClient.GetCreator()
+	if err != nil {
+		reporter.Errorf("Failed to get AWS creator: %v", err)
+		os.Exit(1)
+	}
+
+	// Create the client for the OCM API:
+	ocmConnection, err := ocm.NewConnection().
+		Logger(logger).
+		Build()
+	if err != nil {
+		reporter.Errorf("Failed to create OCM connection: %v", err)
+		os.Exit(1)
+	}
+	defer func() {
+		err = ocmConnection.Close()
+		if err != nil {
+			reporter.Errorf("Failed to close OCM connection: %v", err)
+		}
+	}()
+
+	// Get the client for the OCM collection of clusters:
+	ocmClient := ocmConnection.ClustersMgmt().V1()
+
+	// Try to find the cluster:
+	reporter.Debugf("Loading cluster '%s'", clusterKey)
+	cluster, err := ocm.GetCluster(ocmClient.Clusters(), clusterKey, awsCreator.ARN)
+	if err != nil {
+		reporter.Errorf("Failed to get cluster '%s': %v", clusterKey, err)
+		os.Exit(1)
+	}
+
+	if cluster.State() != cmv1.ClusterStateReady {
+		reporter.Errorf("Cluster '%s' is not yet ready", clusterKey)
+		os.Exit(1)
+	}
+
+	scheduledUpgrade, err := upgrades.GetScheduledUpgrade(ocmClient, cluster.ID())
+	if err != nil {
+		reporter.Errorf("Failed to get scheduled upgrades for cluster '%s': %v", clusterKey, err)
+		os.Exit(1)
+	}
+	if scheduledUpgrade != nil {
+		reporter.Warnf("There is already a scheduled upgrade to version %s on %s",
+			scheduledUpgrade.Version(),
+			scheduledUpgrade.NextRun().Format("2006-01-02 15:04 MST"),
+		)
+		os.Exit(0)
+	}
+
+	version := args.version
+	scheduleDate := args.scheduleDate
+	scheduleTime := args.scheduleTime
+
+	availableUpgrades, err := versions.GetAvailableUpgrades(ocmClient, versions.GetVersionID(cluster))
+	if err != nil {
+		reporter.Errorf("Failed to find available upgrades: %v", err)
+		os.Exit(1)
+	}
+	if len(availableUpgrades) == 0 {
+		reporter.Warnf("There are no available upgrades")
+		os.Exit(0)
+	}
+
+	if version == "" || interactive.Enabled() {
+		if version == "" {
+			version = availableUpgrades[0]
+		}
+		version, err = interactive.GetOption(interactive.Input{
+			Question: "Version",
+			Help:     cmd.Flags().Lookup("version").Usage,
+			Options:  availableUpgrades,
+			Default:  version,
+			Required: true,
+		})
+		if err != nil {
+			reporter.Errorf("Expected a valid version to upgrade to: %s", err)
+			os.Exit(1)
+		}
+	}
+
+	// Check that the version is valid
+	validVersion := false
+	for _, v := range availableUpgrades {
+		if v == version {
+			validVersion = true
+			break
+		}
+	}
+	if !validVersion {
+		reporter.Errorf("Expected a valid version to upgrade to")
+		os.Exit(1)
+	}
+
+	// Set the default next run within the next 10 minutes
+	now := time.Now().UTC().Add(time.Minute * 10)
+	if scheduleDate == "" {
+		scheduleDate = now.Format("2006-01-02")
+	}
+	if scheduleTime == "" {
+		scheduleTime = now.Format("15:04")
+	}
+
+	if interactive.Enabled() {
+		// If datetimes are set, use them in the interactive form, otherwise fallback to 'now'
+		scheduleParsed, err := time.Parse("2006-01-02 15:04", fmt.Sprintf("%s %s", scheduleDate, scheduleTime))
+		if err != nil {
+			scheduleParsed = now
+		}
+		scheduleDate = scheduleParsed.Format("2006-01-02")
+		scheduleTime = scheduleParsed.Format("15:04")
+
+		scheduleDate, err = interactive.GetString(interactive.Input{
+			Question: "Please input desired date in format yyyy-mm-dd",
+			Default:  scheduleDate,
+			Required: true,
+		})
+		if err != nil {
+			reporter.Errorf("Expected a valid date: %s", err)
+			os.Exit(1)
+		}
+		_, err = time.Parse("2006-01-02", scheduleDate)
+		if err != nil {
+			reporter.Errorf("Date format '%s' invalid", scheduleDate)
+			os.Exit(1)
+		}
+
+		scheduleTime, err = interactive.GetString(interactive.Input{
+			Question: "Please input desired UTC time in format HH:mm",
+			Default:  scheduleTime,
+			Required: true,
+		})
+		if err != nil {
+			reporter.Errorf("Expected a valid time: %s", err)
+			os.Exit(1)
+		}
+		_, err = time.Parse("15:04", scheduleTime)
+		if err != nil {
+			reporter.Errorf("Time format '%s' invalid", scheduleTime)
+			os.Exit(1)
+		}
+	}
+
+	// Parse next run to time.Time
+	nextRun, err := time.Parse("2006-01-02 15:04", fmt.Sprintf("%s %s", scheduleDate, scheduleTime))
+	if err != nil {
+		reporter.Errorf("Time format invalid: %s", err)
+		os.Exit(1)
+	}
+
+	upgradePolicyBuilder := cmv1.NewUpgradePolicy().
+		ScheduleType("manual").
+		Version(version).
+		NextRun(nextRun)
+
+	nodeDrainGracePeriod := ""
+	// Determine if the cluster already has a node drain grace period set and use that as the default
+	nd := cluster.NodeDrainGracePeriod()
+	if _, ok := nd.GetValue(); ok {
+		// Convert larger times to hours, since the API only stores minutes
+		val := int(nd.Value())
+		unit := nd.Unit()
+		if val >= 60 {
+			val = val / 60
+			if val == 1 {
+				unit = "hour"
+			} else {
+				unit = "hours"
+			}
+		}
+		nodeDrainGracePeriod = fmt.Sprintf("%d %s", val, unit)
+	}
+	// If node drain grace period is not set, or the user sent it as a CLI argument, use that instead
+	if nodeDrainGracePeriod == "" || cmd.Flags().Changed("node-drain-grace-period") {
+		nodeDrainGracePeriod = args.nodeDrainGracePeriod
+	}
+	nodeDrainOptions := []string{
+		"15 minutes",
+		"30 minutes",
+		"45 minutes",
+		"1 hour",
+		"2 hours",
+		"4 hours",
+		"8 hours",
+	}
+	if interactive.Enabled() {
+		nodeDrainGracePeriod, err = interactive.GetOption(interactive.Input{
+			Question: "Node draining",
+			Help:     cmd.Flags().Lookup("node-drain-grace-period").Usage,
+			Options:  nodeDrainOptions,
+			Default:  nodeDrainGracePeriod,
+			Required: true,
+		})
+		if err != nil {
+			reporter.Errorf("Expected a valid node drain grace period: %s", err)
+			os.Exit(1)
+		}
+	}
+	nodeDrainParsed := strings.Split(nodeDrainGracePeriod, " ")
+	nodeDrainValue, err := strconv.ParseFloat(nodeDrainParsed[0], 64)
+	if err != nil {
+		reporter.Errorf("Expected a valid node drain grace period: %s", err)
+		os.Exit(1)
+	}
+	if nodeDrainParsed[1] == "hours" || nodeDrainParsed[1] == "hour" {
+		nodeDrainValue = nodeDrainValue * 60
+	}
+
+	clusterSpec, err := cmv1.NewCluster().
+		NodeDrainGracePeriod(cmv1.NewValue().
+			Value(nodeDrainValue).
+			Unit("minutes")).
+		Build()
+	if err != nil {
+		reporter.Errorf("Failed to update cluster '%s': %v", clusterKey, err)
+		os.Exit(1)
+	}
+
+	upgradePolicy, err := upgradePolicyBuilder.Build()
+	if err != nil {
+		reporter.Errorf("Failed to schedule upgrade for cluster '%s': %v", clusterKey, err)
+		os.Exit(1)
+	}
+
+	_, err = ocmClient.Clusters().
+		Cluster(cluster.ID()).
+		UpgradePolicies().
+		Add().
+		Body(upgradePolicy).
+		Send()
+	if err != nil {
+		reporter.Errorf("Failed to schedule upgrade for cluster '%s': %v", clusterKey, err)
+		os.Exit(1)
+	}
+
+	_, err = ocmClient.Clusters().
+		Cluster(cluster.ID()).
+		Update().
+		Body(clusterSpec).
+		Send()
+	if err != nil {
+		reporter.Errorf("Failed to update cluster '%s': %v", clusterKey, err)
+		os.Exit(1)
+	}
+
+	reporter.Infof("Upgrade successfully scheduled for cluster '%s'", clusterKey)
+}

--- a/cmd/upgrade/cmd.go
+++ b/cmd/upgrade/cmd.go
@@ -1,0 +1,37 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package upgrade
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/openshift/moactl/cmd/upgrade/cluster"
+	"github.com/openshift/moactl/pkg/interactive"
+)
+
+var Cmd = &cobra.Command{
+	Use:   "upgrade RESOURCE [flags]",
+	Short: "Upgrade a resource",
+	Long:  "Upgrade a resource",
+}
+
+func init() {
+	Cmd.AddCommand(cluster.Cmd)
+
+	flags := Cmd.PersistentFlags()
+	interactive.AddFlag(flags)
+}

--- a/docs/rosa.md
+++ b/docs/rosa.md
@@ -30,6 +30,7 @@ Command line tool for Red Hat OpenShift Service on AWS.
 * [rosa logout](rosa_logout.md)	 - Log out
 * [rosa logs](rosa_logs.md)	 - Show installation or uninstallation logs for a cluster
 * [rosa revoke](rosa_revoke.md)	 - Revoke role from a specific resource
+* [rosa upgrade](rosa_upgrade.md)	 - Upgrade a resource
 * [rosa verify](rosa_verify.md)	 - Verify resources are configured correctly for cluster install
 * [rosa version](rosa_version.md)	 - Prints the version of the tool
 * [rosa whoami](rosa_whoami.md)	 - Displays user account information

--- a/docs/rosa_delete.md
+++ b/docs/rosa_delete.md
@@ -29,4 +29,5 @@ Delete a specific resource
 * [rosa delete idp](rosa_delete_idp.md)	 - Delete cluster IDPs
 * [rosa delete ingress](rosa_delete_ingress.md)	 - Delete cluster ingress
 * [rosa delete machinepool](rosa_delete_machinepool.md)	 - Delete machine pool
+* [rosa delete upgrade](rosa_delete_upgrade.md)	 - Cancel cluster upgrade
 

--- a/docs/rosa_delete_upgrade.md
+++ b/docs/rosa_delete_upgrade.md
@@ -1,0 +1,32 @@
+## rosa delete upgrade
+
+Cancel cluster upgrade
+
+### Synopsis
+
+Cancel scheduled cluster upgrade
+
+```
+rosa delete upgrade [flags]
+```
+
+### Options
+
+```
+  -c, --cluster string   Name or ID of the cluster to cancel the upgrade for (required)
+  -h, --help             help for upgrade
+```
+
+### Options inherited from parent commands
+
+```
+      --debug            Enable debug mode.
+      --profile string   Use a specific AWS profile from your credential file.
+  -v, --v Level          log level for V logs
+  -y, --yes              Automatically answer yes to confirm operation.
+```
+
+### SEE ALSO
+
+* [rosa delete](rosa_delete.md)	 - Delete a specific resource
+

--- a/docs/rosa_list.md
+++ b/docs/rosa_list.md
@@ -28,6 +28,7 @@ List all resources of a specific type
 * [rosa list ingresses](rosa_list_ingresses.md)	 - List cluster Ingresses
 * [rosa list machinepools](rosa_list_machinepools.md)	 - List cluster machine pools
 * [rosa list regions](rosa_list_regions.md)	 - List available regions
+* [rosa list upgrades](rosa_list_upgrades.md)	 - List available cluster upgrades
 * [rosa list users](rosa_list_users.md)	 - List cluster users
 * [rosa list versions](rosa_list_versions.md)	 - List available versions
 

--- a/docs/rosa_list_upgrades.md
+++ b/docs/rosa_list_upgrades.md
@@ -1,0 +1,31 @@
+## rosa list upgrades
+
+List available cluster upgrades
+
+### Synopsis
+
+List available and scheduled cluster version upgrades
+
+```
+rosa list upgrades [flags]
+```
+
+### Options
+
+```
+  -c, --cluster string   Name or ID of the cluster to list the upgrades of (required).
+  -h, --help             help for upgrades
+```
+
+### Options inherited from parent commands
+
+```
+      --debug            Enable debug mode.
+      --profile string   Use a specific AWS profile from your credential file.
+  -v, --v Level          log level for V logs
+```
+
+### SEE ALSO
+
+* [rosa list](rosa_list.md)	 - List all resources of a specific type
+

--- a/docs/rosa_upgrade.md
+++ b/docs/rosa_upgrade.md
@@ -1,0 +1,28 @@
+## rosa upgrade
+
+Upgrade a resource
+
+### Synopsis
+
+Upgrade a resource
+
+### Options
+
+```
+  -h, --help          help for upgrade
+  -i, --interactive   Enable interactive mode.
+```
+
+### Options inherited from parent commands
+
+```
+      --debug            Enable debug mode.
+      --profile string   Use a specific AWS profile from your credential file.
+  -v, --v Level          log level for V logs
+```
+
+### SEE ALSO
+
+* [rosa](rosa.md)	 - Command line tool for ROSA.
+* [rosa upgrade cluster](rosa_upgrade_cluster.md)	 - Upgrade cluster
+

--- a/docs/rosa_upgrade_cluster.md
+++ b/docs/rosa_upgrade_cluster.md
@@ -1,0 +1,47 @@
+## rosa upgrade cluster
+
+Upgrade cluster
+
+### Synopsis
+
+Upgrade cluster to a new available version
+
+```
+rosa upgrade cluster [flags]
+```
+
+### Examples
+
+```
+  # Interactively schedule an upgrade on the cluster named "mycluster"
+  rosa upgrade cluster --cluster=mycluster --interactive
+
+  # Schedule a cluster upgrade within the hour
+  rosa upgade cluster -c mycluster --version 4.5.20
+```
+
+### Options
+
+```
+  -c, --cluster string                   Name or ID of the cluster to schedule the upgrade for (required)
+      --version string                   Version of OpenShift that the cluster will be upgraded to
+      --schedule-date string             Next date the upgrade should run at the specified time. Format should be 'yyyy-mm-dd'
+      --schedule-time string             Next time the upgrade should run on the specified date. Format should be 'HH:mm'
+      --node-drain-grace-period string   You may set a grace period for how long Pod Disruption Budget-protected workloads will be respected during upgrades.
+                                         After this grace period, any workloads protected by Pod Disruption Budgets that have not been successfully drained from a node will be forcibly evicted (default "1 hour")
+  -h, --help                             help for cluster
+```
+
+### Options inherited from parent commands
+
+```
+      --debug            Enable debug mode.
+  -i, --interactive      Enable interactive mode.
+      --profile string   Use a specific AWS profile from your credential file.
+  -v, --v Level          log level for V logs
+```
+
+### SEE ALSO
+
+* [rosa upgrade](rosa_upgrade.md)	 - Upgrade a resource
+

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/onsi/ginkgo v1.11.0
 	github.com/onsi/gomega v1.7.0
-	github.com/openshift-online/ocm-sdk-go v0.1.146
+	github.com/openshift-online/ocm-sdk-go v0.1.150
 	github.com/prometheus/common v0.11.1 // indirect
 	github.com/sirupsen/logrus v1.6.0
 	github.com/spf13/cobra v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -281,6 +281,8 @@ github.com/onsi/gomega v1.7.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1Cpa
 github.com/op/go-logging v0.0.0-20160315200505-970db520ece7/go.mod h1:HzydrMdWErDVzsI23lYNej1Htcns9BCg93Dk0bBINWk=
 github.com/openshift-online/ocm-sdk-go v0.1.146 h1:6HQj+BwWk08PrZVoxk52QWjVLNMafGKBMmZMir46zyM=
 github.com/openshift-online/ocm-sdk-go v0.1.146/go.mod h1:3i3a/LEYtC7DMor3N94PTPn1+0qq+Fk+iLjt1Z0WVCs=
+github.com/openshift-online/ocm-sdk-go v0.1.150 h1:z3rcSmYmbU3PpP9DhpQRkL8ngHFBTR59zOOjVinCTtM=
+github.com/openshift-online/ocm-sdk-go v0.1.150/go.mod h1:wtDv/a2arfeFkYpgQg6J7axTwXkrlSifaVRWeZkUZzo=
 github.com/opentracing-contrib/go-observer v0.0.0-20170622124052-a52f23424492/go.mod h1:Ngi6UdF0k5OKD5t5wlmGhe/EDKPoUM3BXZSSfIuJbis=
 github.com/opentracing/basictracer-go v1.0.0/go.mod h1:QfBfYuafItcjQuMwinw9GhYKwFXS9KnPs5lxoYwgW74=
 github.com/opentracing/opentracing-go v1.0.2/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
@@ -559,6 +561,8 @@ gopkg.in/yaml.v2 v2.2.5/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.3.0 h1:clyUAQHOM3G0M3f5vQj7LuJrETvjVot3Z5el9nffUtU=
 gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776 h1:tQIYjPdBoyREyB9XMu+nnTclpTYkz2zFM+lzLJFO4gQ=
+gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 honnef.co/go/tools v0.0.0-20180728063816-88497007e858/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/pkg/ocm/upgrades/upgrades.go
+++ b/pkg/ocm/upgrades/upgrades.go
@@ -1,0 +1,87 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package upgrades
+
+import (
+	"errors"
+
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	ocmerrors "github.com/openshift-online/ocm-sdk-go/errors"
+)
+
+func GetUpgradePolicies(client *cmv1.Client, clusterID string) (upgradePolicies []*cmv1.UpgradePolicy, err error) {
+	collection := client.Clusters().Cluster(clusterID).UpgradePolicies()
+	page := 1
+	size := 100
+	for {
+		response, err := collection.List().
+			Page(page).
+			Size(size).
+			Send()
+		if err != nil {
+			return nil, handleErr(response.Error(), err)
+		}
+		upgradePolicies = append(upgradePolicies, response.Items().Slice()...)
+		if response.Size() < size {
+			break
+		}
+		page++
+	}
+	return
+}
+
+func GetScheduledUpgrade(client *cmv1.Client, clusterID string) (*cmv1.UpgradePolicy, error) {
+	upgradePolicies, err := GetUpgradePolicies(client, clusterID)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, upgradePolicy := range upgradePolicies {
+		if upgradePolicy.ScheduleType() == "manual" && upgradePolicy.UpgradeType() == "OSD" {
+			return upgradePolicy, nil
+		}
+	}
+
+	return nil, nil
+}
+
+func CancelUpgrade(client *cmv1.Client, clusterID string) (bool, error) {
+	scheduledUpgrade, err := GetScheduledUpgrade(client, clusterID)
+	if err != nil || scheduledUpgrade == nil {
+		return false, err
+	}
+
+	response, err := client.Clusters().
+		Cluster(clusterID).
+		UpgradePolicies().
+		UpgradePolicy(scheduledUpgrade.ID()).
+		Delete().
+		Send()
+	if err != nil {
+		return false, handleErr(response.Error(), err)
+	}
+
+	return true, nil
+}
+
+func handleErr(res *ocmerrors.Error, err error) error {
+	msg := res.Reason()
+	if msg == "" {
+		msg = err.Error()
+	}
+	return errors.New(msg)
+}


### PR DESCRIPTION
When there are available OpenShift version upgrades for a cluster, this
set of commands will allow the customer to list, schedule, and cancel
them as needed.

https://asciinema.org/a/DSX7yu5NIDQ74vzeoWVroUqKQ