### PR TITLE
Release v0.1.3

### DIFF
--- a/CHANGES.adoc
+++ b/CHANGES.adoc
@@ -3,6 +3,15 @@
 This document describes the relevant changes between releases of the `moactl`
 command line tool.
 
+== 0.1.3 Dec 4 2020
+
+- create: Ask user before showing subnets
+- Dont ignore subnets from command line args if provided
+- [rosa create cluster] Verify provided subnets for Existing VPC exist in AWS
+- Remove paid AMI flag and finalize ROSA transition
+- add taints to machinepool commands
+- upgrades: Allow scheduling, listing, canceling cluster upgrades
+
 == 0.1.2 Nov 24 2020
 
 - Remove API ingress when listing ingress

--- a/pkg/info/info.go
+++ b/pkg/info/info.go
@@ -18,4 +18,4 @@ limitations under the License.
 
 package info
 
-const Version = "0.1.2"
+const Version = "0.1.3"


### PR DESCRIPTION
- create: Ask user before showing subnets
- Dont ignore subnets from command line args if provided
- [rosa create cluster] Verify provided subnets for Existing VPC exist in AWS
- Remove paid AMI flag and finalize ROSA transition
- add taints to machinepool commands
- upgrades: Allow scheduling, listing, canceling cluster upgrades